### PR TITLE
Fix build on macos by ignoring path case sensitivity error

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ library:
   ghc-options:
   - -W
   - -Werror
+  - -optP-Wno-nonportable-include-path
 
 executables:
   jikka:
@@ -50,6 +51,7 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -optP-Wno-nonportable-include-path
     dependencies:
     - Jikka
 
@@ -63,6 +65,7 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -optP-Wno-nonportable-include-path
     dependencies:
     - Jikka
     - ormolu
@@ -78,6 +81,7 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -optP-Wno-nonportable-include-path
     dependencies:
     - Jikka
     - doctest


### PR DESCRIPTION
Closes #27

Added `-optP-Wno-nonportable-include-path` option to each `ghc-options`, so that build on macOS succeeds
ref: https://github.com/haskell/cabal/issues/4739#issuecomment-359209133