### PR TITLE
Fix scripts/pre-commit

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -12,8 +12,7 @@ git diff --exit-code *.cabal \
 # C++
 which clang-format \
     || { echo HINT: Please install clang-format; false; }
-for f in $(find runtime/include examples/data -name \*.\?pp); do diff $f <(clang-format $f); done \
-    || { echo HINT: Please run '$ clang-format -i $(find runtime/include examples/data -name \*.\?pp);' ; false; }
+for f in $(find runtime/include examples/data -name \*.\?pp); do diff $f <(clang-format $f) || { echo HINT: Please run '$ clang-format -i $(find runtime/include examples/data -name \*.\?pp);' ; false; }; done
 
 # Python
 isort --version \


### PR DESCRIPTION
**問題**: pre-commitを設定して、clang-formatをかけるときに、for文の結果を渡しているため、
```txt
a.cpp # ok
b.cpp # ng
c.cpp # ok
```
のように最後がokで途中がngの順で検査すると、最後のokでExit code 0を受け取って `HINT...` 以降が働かなくなるのでcommitされてしまいます。

**改善策**: フォーマットすべきファイルが出たらそこで止めるようにしました。(ヒントを実行すれば一括でフォーマットされるのですべての警告を表示せず打ち切ってよさそうです。)