### PR TITLE
fix(cxx): Always add int64 suffix to int64 literals

### DIFF
--- a/src/Jikka/CPlusPlus/Format.hs
+++ b/src/Jikka/CPlusPlus/Format.hs
@@ -196,9 +196,7 @@ formatType = \case
 formatLiteral :: Literal -> Code
 formatLiteral = \case
   LitInt32 n -> show n
-  LitInt64 n
-    | - (2 ^ 31) <= n && n < 2 ^ 31 -> show n
-    | otherwise -> show n ++ "ll"
+  LitInt64 n -> show n ++ "ll"
   LitBool p -> if p then "true" else "false"
   LitChar c -> show c
   LitString s -> show s

--- a/test/Jikka/CPlusPlus/FormatSpec.hs
+++ b/test/Jikka/CPlusPlus/FormatSpec.hs
@@ -35,7 +35,7 @@ spec = do
               ]
       let formatted =
             [ "int64_t solve(int32_t n) {",
-              "    int64_t x = 0;",
+              "    int64_t x = 0ll;",
               "    for (int32_t i = 0; i < n; ++ i) {",
               "        x += int64_t(i);",
               "    }",
@@ -65,7 +65,7 @@ spec = do
               ]
       let formatted =
             [ "int64_t solve(int32_t n, std::vector<int64_t> h) {",
-              "    int64_t x = 0;",
+              "    int64_t x = 0ll;",
               "    for (int32_t i = 2; i < n; ++ i) {",
               "        x += h[i - 2];",
               "    }",


### PR DESCRIPTION
#202 

## Summary
- int64 の定数リテラルに対し、その定数が int32 の範囲でも接尾辞 `ll` を付加するように変更した

## Tests
- この変更により、abc186_d を AC するコードを出力するようになったことを確認した
  - https://atcoder.jp/contests/abc186/submissions/25500207
