### PR TITLE
refactor: Use (string, int) for names instead of just a string

### DIFF
--- a/Jikka.cabal
+++ b/Jikka.cabal
@@ -58,6 +58,7 @@ library
       Jikka.Common.Location
       Jikka.Common.Matrix
       Jikka.Common.ModInt
+      Jikka.Common.Name
       Jikka.Common.Parse.JoinLines
       Jikka.Common.Parse.OffsideRule
       Jikka.Common.Parse.Read

--- a/Jikka.cabal
+++ b/Jikka.cabal
@@ -116,6 +116,7 @@ library
       Jikka.CPlusPlus.Convert
       Jikka.CPlusPlus.Convert.AddMain
       Jikka.CPlusPlus.Convert.BundleRuntime
+      Jikka.CPlusPlus.Convert.BurnFlavouredNames
       Jikka.CPlusPlus.Convert.EmbedOriginalCode
       Jikka.CPlusPlus.Convert.FromCore
       Jikka.CPlusPlus.Convert.InlineSetAt

--- a/src/Jikka/CPlusPlus/Convert/AddMain.hs
+++ b/src/Jikka/CPlusPlus/Convert/AddMain.hs
@@ -46,7 +46,7 @@ runMainDeclare format = go M.empty (F.inputTree format)
     go sizes = \case
       F.Exp e -> do
         (x, indices) <- F.unpackSubscriptedVar e
-        y <- renameVarName' LocalNameKind x
+        y <- renameVarName' LocalNameHint x
         modify' $ M.insert x y
         let lookupSize i = case M.lookup i sizes of
               Just e -> return e
@@ -78,7 +78,7 @@ runMainInput format decls = do
           (stmts', initialized) <- go initialized (F.Seq formats)
           return (stmts ++ stmts', initialized)
         F.Loop i n body -> do
-          j <- renameVarName' LoopCounterNameKind i
+          j <- renameVarName' LoopCounterNameHint i
           modify' $ M.insert i j
           n <- runFormatExpr n
           (body, initialized) <- go initialized body
@@ -93,11 +93,11 @@ runMainSolve format = do
   let solve = Call' (Function "solve" []) (map Var args)
   case F.outputVariables format of
     Left x -> do
-      y <- renameVarName' LocalNameKind x
+      y <- renameVarName' LocalNameHint x
       modify' $ M.insert x y
       return $ Declare TyAuto y (DeclareCopy solve)
     Right xs -> do
-      ys <- mapM (renameVarName' LocalNameKind) xs
+      ys <- mapM (renameVarName' LocalNameHint) xs
       modify' $ \env -> foldl (\env (x, y) -> M.insert x y env) env (zip xs ys)
       return $ DeclareDestructure ys solve
 
@@ -111,7 +111,7 @@ runMainOutput format = go (F.outputTree format)
       F.Newline -> return [coutStatement (Lit (LitChar '\n'))]
       F.Seq formats -> concat <$> mapM go formats
       F.Loop i n body -> do
-        j <- renameVarName' LoopCounterNameKind i
+        j <- renameVarName' LoopCounterNameHint i
         modify' $ M.insert i j
         n <- runFormatExpr n
         body <- go body

--- a/src/Jikka/CPlusPlus/Convert/AddMain.hs
+++ b/src/Jikka/CPlusPlus/Convert/AddMain.hs
@@ -38,7 +38,7 @@ runFormatExpr = \case
   F.At e i -> at <$> runFormatExpr e <*> (Var <$> lookup' i)
   F.Len e -> do
     e <- runFormatExpr e
-    return $ cast TyInt32 (Call MethodSize [e])
+    return $ cast TyInt32 (Call' MethodSize [e])
 
 runMainDeclare :: (MonadState (M.Map String VarName) m, MonadAlpha m, MonadError Error m) => F.IOFormat -> m [(S.Set VarName, Statement)]
 runMainDeclare format = go M.empty (F.inputTree format)
@@ -46,7 +46,7 @@ runMainDeclare format = go M.empty (F.inputTree format)
     go sizes = \case
       F.Exp e -> do
         (x, indices) <- F.unpackSubscriptedVar e
-        y <- renameVarName LocalNameKind x
+        y <- renameVarName' LocalNameKind x
         modify' $ M.insert x y
         let lookupSize i = case M.lookup i sizes of
               Just e -> return e
@@ -78,7 +78,7 @@ runMainInput format decls = do
           (stmts', initialized) <- go initialized (F.Seq formats)
           return (stmts ++ stmts', initialized)
         F.Loop i n body -> do
-          j <- renameVarName LoopCounterNameKind i
+          j <- renameVarName' LoopCounterNameKind i
           modify' $ M.insert i j
           n <- runFormatExpr n
           (body, initialized) <- go initialized body
@@ -90,14 +90,14 @@ runMainInput format decls = do
 runMainSolve :: (MonadState (M.Map String VarName) m, MonadAlpha m, MonadError Error m) => F.IOFormat -> m Statement
 runMainSolve format = do
   args <- mapM lookup' (F.inputVariables format)
-  let solve = Call (Function "solve" []) (map Var args)
+  let solve = Call' (Function "solve" []) (map Var args)
   case F.outputVariables format of
     Left x -> do
-      y <- renameVarName LocalNameKind x
+      y <- renameVarName' LocalNameKind x
       modify' $ M.insert x y
       return $ Declare TyAuto y (DeclareCopy solve)
     Right xs -> do
-      ys <- mapM (renameVarName LocalNameKind) xs
+      ys <- mapM (renameVarName' LocalNameKind) xs
       modify' $ \env -> foldl (\env (x, y) -> M.insert x y env) env (zip xs ys)
       return $ DeclareDestructure ys solve
 
@@ -111,7 +111,7 @@ runMainOutput format = go (F.outputTree format)
       F.Newline -> return [coutStatement (Lit (LitChar '\n'))]
       F.Seq formats -> concat <$> mapM go formats
       F.Loop i n body -> do
-        j <- renameVarName LoopCounterNameKind i
+        j <- renameVarName' LoopCounterNameKind i
         modify' $ M.insert i j
         n <- runFormatExpr n
         body <- go body

--- a/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
+++ b/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+-- |
+-- Module      : Jikka.CPlusPlus.Convert.BurnFlavouredNames
+-- Description : remove unique numbers from names as a preprocess to emit the result source code. / 結果のソースコードを出力する前処理として、名前に付けられた一意な整数を解決します。
+-- Copyright   : (c) Kimiyuki Onaka, 2020
+-- License     : Apache License 2.0
+-- Maintainer  : kimiyuki95@gmail.com
+-- Stability   : experimental
+-- Portability : portable
+module Jikka.CPlusPlus.Convert.BurnFlavouredNames
+  ( run,
+  )
+where
+
+import Control.Monad.State.Strict
+import qualified Data.Map as M
+import Data.Maybe
+import qualified Data.Set as S
+import Jikka.CPlusPlus.Language.Expr
+import Jikka.CPlusPlus.Language.Util
+import Jikka.Common.Alpha
+import Jikka.Common.Error
+
+data Env = Env
+  { renameMapping :: M.Map VarName VarName,
+    usedVars :: S.Set String
+  }
+  deriving (Eq, Ord, Read, Show)
+
+emptyEnv :: Env
+emptyEnv =
+  Env
+    { renameMapping = M.empty,
+      usedVars = S.empty
+    }
+
+fromNameKind :: Maybe NameKind -> String
+fromNameKind = \case
+  Nothing -> "u"
+  Just LocalNameKind -> "x"
+  Just LocalArgumentNameKind -> "b"
+  Just LoopCounterNameKind -> "i"
+  Just ConstantNameKind -> "c"
+  Just FunctionNameKind -> "f"
+  Just ArgumentNameKind -> "a"
+
+chooseOccName :: S.Set String -> VarName -> String
+chooseOccName used (VarName occ _ kind) =
+  let occ_workaround = (\s -> if '$' `elem` s then Nothing else Just s) =<< occ -- TODO: Remove this after Python stops using variables with `$`.
+      base = fromMaybe (fromNameKind kind) occ_workaround
+      occs = base : map (\i -> base ++ show i) [2 ..]
+      occ' = head $ filter (`S.notMember` used) occs
+   in occ'
+
+rename :: MonadState Env m => VarName -> m VarName
+rename x = do
+  y <- gets $ M.lookup x . renameMapping
+  case y of
+    Just y -> return y
+    Nothing -> do
+      y' <- flip chooseOccName x <$> gets usedVars
+      let y = VarName (Just y') Nothing Nothing
+      modify $ \env ->
+        env
+          { renameMapping = M.insert x y (renameMapping env),
+            usedVars = S.insert y' (usedVars env)
+          }
+      return y
+
+mapVarNameExprStatementGenericM :: forall m a. Monad m => ((Expr -> m Expr) -> (Statement -> m [Statement]) -> a) -> (VarName -> m VarName) -> a
+mapVarNameExprStatementGenericM mapExprStatementM f = mapExprStatementM goE (fmap (: []) . goS)
+  where
+    goE :: Monad m => Expr -> m Expr
+    goE = \case
+      Var x -> Var <$> f x
+      Lam args ret body -> Lam <$> mapM (\(t, x) -> (t,) <$> f x) args <*> pure ret <*> pure body
+      e -> return e
+    goLeftExpr :: Monad m => LeftExpr -> m LeftExpr
+    goLeftExpr = \case
+      LeftVar x -> LeftVar <$> f x
+      LeftAt e1 e2 -> LeftAt <$> goLeftExpr e1 <*> pure e2
+      LeftGet n e -> LeftGet n <$> goLeftExpr e
+    goAssignExpr :: Monad m => AssignExpr -> m AssignExpr
+    goAssignExpr = \case
+      AssignExpr op e1 e2 -> AssignExpr op <$> goLeftExpr e1 <*> pure e2
+      AssignIncr e -> AssignIncr <$> goLeftExpr e
+      AssignDecr e -> AssignDecr <$> goLeftExpr e
+    goS :: Monad m => Statement -> m Statement
+    goS = \case
+      For t x init pred incr body -> For t <$> f x <*> pure init <*> pure pred <*> goAssignExpr incr <*> pure body
+      ForEach t x e body -> ForEach t <$> f x <*> pure e <*> pure body
+      Declare t x init -> Declare t <$> f x <*> pure init
+      DeclareDestructure xs e -> DeclareDestructure <$> mapM f xs <*> pure e
+      Assign e -> Assign <$> goAssignExpr e
+      stmt -> return stmt
+
+mapVarNameToplevelStatementM :: Monad m => (VarName -> m VarName) -> ToplevelStatement -> m ToplevelStatement
+mapVarNameToplevelStatementM f stmt = do
+  stmt <- case stmt of
+    VarDef t x e -> VarDef t <$> f x <*> pure e
+    FunDef ret g args body -> FunDef ret g <$> mapM (\(t, x) -> (t,) <$> f x) args <*> pure body
+    _ -> return stmt
+  mapVarNameExprStatementGenericM mapExprStatementToplevelStatementM f stmt
+
+mapVarNameProgramM :: Monad m => (VarName -> m VarName) -> Program -> m Program
+mapVarNameProgramM f = mapToplevelStatementProgramM (fmap (: []) . mapVarNameToplevelStatementM f)
+
+runProgram :: MonadState Env m => Program -> m Program
+runProgram = mapVarNameProgramM rename
+
+run :: (MonadAlpha m, MonadError Error m) => Program -> m Program
+run prog = wrapError' "Jikka.CPlusPlus.Convert.BurnFlavouredNames" $ do
+  evalStateT (runProgram prog) emptyEnv

--- a/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
+++ b/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
@@ -38,8 +38,8 @@ emptyEnv =
       usedVars = S.empty
     }
 
-fromNameKind :: Maybe NameHint -> String
-fromNameKind = \case
+fromNameHint :: Maybe NameHint -> String
+fromNameHint = \case
   Nothing -> "u"
   Just LocalNameHint -> "x"
   Just LocalArgumentNameHint -> "b"
@@ -47,11 +47,12 @@ fromNameKind = \case
   Just ConstantNameHint -> "c"
   Just FunctionNameHint -> "f"
   Just ArgumentNameHint -> "a"
+  Just (AdHocNameHint hint) -> hint
 
 chooseOccName :: S.Set String -> VarName -> String
 chooseOccName used (VarName occ _ kind) =
   let occ_workaround = (\s -> if '$' `elem` s then Nothing else Just s) =<< occ -- TODO: Remove this after Python stops using variables with `$`.
-      base = fromMaybe (fromNameKind kind) occ_workaround
+      base = fromMaybe (fromNameHint kind) occ_workaround
       occs = base : map (\i -> base ++ show i) [2 ..]
       occ' = head $ filter (`S.notMember` used) occs
    in occ'

--- a/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
+++ b/src/Jikka/CPlusPlus/Convert/BurnFlavouredNames.hs
@@ -38,15 +38,15 @@ emptyEnv =
       usedVars = S.empty
     }
 
-fromNameKind :: Maybe NameKind -> String
+fromNameKind :: Maybe NameHint -> String
 fromNameKind = \case
   Nothing -> "u"
-  Just LocalNameKind -> "x"
-  Just LocalArgumentNameKind -> "b"
-  Just LoopCounterNameKind -> "i"
-  Just ConstantNameKind -> "c"
-  Just FunctionNameKind -> "f"
-  Just ArgumentNameKind -> "a"
+  Just LocalNameHint -> "x"
+  Just LocalArgumentNameHint -> "b"
+  Just LoopCounterNameHint -> "i"
+  Just ConstantNameHint -> "c"
+  Just FunctionNameHint -> "f"
+  Just ArgumentNameHint -> "a"
 
 chooseOccName :: S.Set String -> VarName -> String
 chooseOccName used (VarName occ _ kind) =

--- a/src/Jikka/CPlusPlus/Convert/FromCore.hs
+++ b/src/Jikka/CPlusPlus/Convert/FromCore.hs
@@ -19,6 +19,7 @@ module Jikka.CPlusPlus.Convert.FromCore
 where
 
 import Control.Monad.Writer.Strict
+import Data.Maybe
 import qualified Jikka.CPlusPlus.Language.Expr as Y
 import qualified Jikka.CPlusPlus.Language.Util as Y
 import Jikka.Common.Alpha
@@ -35,7 +36,7 @@ import qualified Jikka.Core.Language.Util as X
 -- monad
 
 renameVarName' :: MonadAlpha m => Y.NameKind -> X.VarName -> m Y.VarName
-renameVarName' kind x = Y.renameVarName kind (X.unVarName x)
+renameVarName' kind (X.VarName x _) = Y.renameVarName kind (fromMaybe "" x)
 
 type Env = [(X.VarName, X.Type, Y.VarName)]
 
@@ -45,7 +46,7 @@ typecheckExpr env = X.typecheckExpr (map (\(x, t, _) -> (x, t)) env)
 lookupVarName :: MonadError Error m => Env -> X.VarName -> m Y.VarName
 lookupVarName env x = case lookup x (map (\(x, _, y) -> (x, y)) env) of
   Just y -> return y
-  Nothing -> throwInternalError $ "undefined variable: " ++ X.unVarName x
+  Nothing -> throwInternalError $ "undefined variable: " ++ X.formatVarName x
 
 class Monad m => MonadStatements m where
   useStatement :: Y.Statement -> m ()

--- a/src/Jikka/CPlusPlus/Convert/FromCore.hs
+++ b/src/Jikka/CPlusPlus/Convert/FromCore.hs
@@ -19,7 +19,6 @@ module Jikka.CPlusPlus.Convert.FromCore
 where
 
 import Control.Monad.Writer.Strict
-import Data.Maybe
 import qualified Jikka.CPlusPlus.Language.Expr as Y
 import qualified Jikka.CPlusPlus.Language.Util as Y
 import Jikka.Common.Alpha
@@ -36,17 +35,56 @@ import qualified Jikka.Core.Language.Util as X
 -- monad
 
 renameVarName' :: MonadAlpha m => Y.NameKind -> X.VarName -> m Y.VarName
-renameVarName' kind (X.VarName x _) = Y.renameVarName kind (fromMaybe "" x)
+renameVarName' kind (X.VarName occ _) = case occ of
+  Nothing -> Y.newFreshName kind
+  Just occ -> Y.renameVarName' kind occ
 
-type Env = [(X.VarName, X.Type, Y.VarName)]
+renameFunName' :: MonadError Error m => X.VarName -> m Y.FunName
+renameFunName' = \case
+  X.VarName (Just occ) _ -> return $ Y.FunName occ
+  _ -> throwInternalError "annonymous toplevel-let is not allowed"
+
+data Env = Env
+  { typeEnv :: [(X.VarName, X.Type)],
+    varMapping :: [(X.VarName, Y.VarName)],
+    funMapping :: [(X.VarName, Y.FunName)]
+  }
+  deriving (Eq, Ord, Show, Read)
+
+emptyEnv :: Env
+emptyEnv =
+  Env
+    { typeEnv = [],
+      varMapping = [],
+      funMapping = []
+    }
+
+pushVar :: X.VarName -> X.Type -> Y.VarName -> Env -> Env
+pushVar x t y env =
+  env
+    { typeEnv = (x, t) : typeEnv env,
+      varMapping = (x, y) : varMapping env
+    }
+
+pushFun :: X.VarName -> X.Type -> Y.FunName -> Env -> Env
+pushFun x t y env =
+  env
+    { typeEnv = (x, t) : typeEnv env,
+      funMapping = (x, y) : funMapping env
+    }
 
 typecheckExpr :: MonadError Error m => Env -> X.Expr -> m X.Type
-typecheckExpr env = X.typecheckExpr (map (\(x, t, _) -> (x, t)) env)
+typecheckExpr env = X.typecheckExpr (typeEnv env)
 
 lookupVarName :: MonadError Error m => Env -> X.VarName -> m Y.VarName
-lookupVarName env x = case lookup x (map (\(x, _, y) -> (x, y)) env) of
+lookupVarName env x = case lookup x (varMapping env) of
   Just y -> return y
   Nothing -> throwInternalError $ "undefined variable: " ++ X.formatVarName x
+
+lookupFunName :: MonadError Error m => Env -> X.VarName -> m Y.FunName
+lookupFunName env x = case lookup x (funMapping env) of
+  Just y -> return y
+  Nothing -> throwInternalError $ "undefined function: " ++ X.formatVarName x
 
 class Monad m => MonadStatements m where
   useStatement :: Y.Statement -> m ()
@@ -106,7 +144,7 @@ runLiteral env = \case
     return $ Y.vecCtor t []
   X.LitBottom t err -> do
     t <- runType t
-    return $ Y.Call (Y.Function "jikka::error" [t]) [Y.Lit (Y.LitString err)]
+    return $ Y.Call' (Y.Function "jikka::error" [t]) [Y.Lit (Y.LitString err)]
 
 arityOfBuiltin :: MonadError Error m => X.Builtin -> [X.Type] -> m Int
 arityOfBuiltin builtin ts = case builtin of
@@ -266,18 +304,18 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
     X.Plus -> go02 $ \e1 e2 -> Y.BinOp Y.Add e1 e2
     X.Minus -> go02 $ \e1 e2 -> Y.BinOp Y.Sub e1 e2
     X.Mult -> go02 $ \e1 e2 -> Y.BinOp Y.Mul e1 e2
-    X.FloorDiv -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::floordiv" []) [e1, e2]
-    X.FloorMod -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::floormod" []) [e1, e2]
-    X.CeilDiv -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::ceildiv" []) [e1, e2]
-    X.CeilMod -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::ceilmod" []) [e1, e2]
-    X.JustDiv -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::justdiv" []) [e1, e2]
-    X.Pow -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::notmod::pow" []) [e1, e2]
+    X.FloorDiv -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::floordiv" []) [e1, e2]
+    X.FloorMod -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::floormod" []) [e1, e2]
+    X.CeilDiv -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::ceildiv" []) [e1, e2]
+    X.CeilMod -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::ceilmod" []) [e1, e2]
+    X.JustDiv -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::justdiv" []) [e1, e2]
+    X.Pow -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::notmod::pow" []) [e1, e2]
     -- advanced arithmetical functions
-    X.Abs -> go01 $ \e -> Y.Call (Y.Function "std::abs" []) [e]
-    X.Gcd -> go02 $ \e1 e2 -> Y.Call (Y.Function "std::gcd" []) [e1, e2]
-    X.Lcm -> go02 $ \e1 e2 -> Y.Call (Y.Function "std::lcm" []) [e1, e2]
-    X.Min2 -> go12 $ \t e1 e2 -> Y.Call (Y.Function "std::min" [t]) [e1, e2]
-    X.Max2 -> go12 $ \t e1 e2 -> Y.Call (Y.Function "std::max" [t]) [e1, e2]
+    X.Abs -> go01 $ \e -> Y.Call' (Y.Function "std::abs" []) [e]
+    X.Gcd -> go02 $ \e1 e2 -> Y.Call' (Y.Function "std::gcd" []) [e1, e2]
+    X.Lcm -> go02 $ \e1 e2 -> Y.Call' (Y.Function "std::lcm" []) [e1, e2]
+    X.Min2 -> go12 $ \t e1 e2 -> Y.Call' (Y.Function "std::min" [t]) [e1, e2]
+    X.Max2 -> go12 $ \t e1 e2 -> Y.Call' (Y.Function "std::max" [t]) [e1, e2]
     X.Iterate -> go13'' $ runIterate env
     -- logical functions
     X.Not -> go01 $ \e -> Y.UnOp Y.Not e
@@ -293,25 +331,25 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
     X.BitLeftShift -> go02 $ \e1 e2 -> Y.BinOp Y.BitLeftShift e1 e2
     X.BitRightShift -> go02 $ \e1 e2 -> Y.BinOp Y.BitRightShift e1 e2
     -- matrix functions
-    X.MatAp h w -> go02 $ \f x -> Y.Call (Y.Function "jikka::mat::ap" [Y.TyIntValue h, Y.TyIntValue w]) [f, x]
-    X.MatZero h w -> go00 $ Y.Call (Y.Function "jikka::mat::zero" [Y.TyIntValue h, Y.TyIntValue w]) []
-    X.MatOne n -> go00 $ Y.Call (Y.Function "jikka::mat::one" [Y.TyIntValue n]) []
-    X.MatAdd h w -> go02 $ \f g -> Y.Call (Y.Function "jikka::mat::add" [Y.TyIntValue h, Y.TyIntValue w]) [f, g]
-    X.MatMul h n w -> go02 $ \f g -> Y.Call (Y.Function "jikka::mat::mul" [Y.TyIntValue h, Y.TyIntValue n, Y.TyIntValue w]) [f, g]
-    X.MatPow n -> go02 $ \f k -> Y.Call (Y.Function "jikka::mat::pow" [Y.TyIntValue n]) [f, k]
-    X.VecFloorMod n -> go02 $ \x m -> Y.Call (Y.Function "jikka::modmat::floormod" [Y.TyIntValue n]) [x, m]
-    X.MatFloorMod h w -> go02 $ \f m -> Y.Call (Y.Function "jikka::modmat::floormod" [Y.TyIntValue h, Y.TyIntValue w]) [f, m]
+    X.MatAp h w -> go02 $ \f x -> Y.Call' (Y.Function "jikka::mat::ap" [Y.TyIntValue h, Y.TyIntValue w]) [f, x]
+    X.MatZero h w -> go00 $ Y.Call' (Y.Function "jikka::mat::zero" [Y.TyIntValue h, Y.TyIntValue w]) []
+    X.MatOne n -> go00 $ Y.Call' (Y.Function "jikka::mat::one" [Y.TyIntValue n]) []
+    X.MatAdd h w -> go02 $ \f g -> Y.Call' (Y.Function "jikka::mat::add" [Y.TyIntValue h, Y.TyIntValue w]) [f, g]
+    X.MatMul h n w -> go02 $ \f g -> Y.Call' (Y.Function "jikka::mat::mul" [Y.TyIntValue h, Y.TyIntValue n, Y.TyIntValue w]) [f, g]
+    X.MatPow n -> go02 $ \f k -> Y.Call' (Y.Function "jikka::mat::pow" [Y.TyIntValue n]) [f, k]
+    X.VecFloorMod n -> go02 $ \x m -> Y.Call' (Y.Function "jikka::modmat::floormod" [Y.TyIntValue n]) [x, m]
+    X.MatFloorMod h w -> go02 $ \f m -> Y.Call' (Y.Function "jikka::modmat::floormod" [Y.TyIntValue h, Y.TyIntValue w]) [f, m]
     -- modular functions
-    X.ModNegate -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::mod::negate" []) [e1, e2]
-    X.ModPlus -> go03 $ \e1 e2 e3 -> Y.Call (Y.Function "jikka::mod::plus" []) [e1, e2, e3]
-    X.ModMinus -> go03 $ \e1 e2 e3 -> Y.Call (Y.Function "jikka::mod::minus" []) [e1, e2, e3]
-    X.ModMult -> go03 $ \e1 e2 e3 -> Y.Call (Y.Function "jikka::mod::mult" []) [e1, e2, e3]
-    X.ModInv -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::mod::inv" []) [e1, e2]
-    X.ModPow -> go03 $ \e1 e2 e3 -> Y.Call (Y.Function "jikka::mod::pow" []) [e1, e2, e3]
-    X.ModMatAp h w -> go03 $ \f x m -> Y.Call (Y.Function "jikka::modmat::ap" [Y.TyIntValue h, Y.TyIntValue w]) [f, x, m]
-    X.ModMatAdd h w -> go03 $ \f g m -> Y.Call (Y.Function "jikka::modmat::add" [Y.TyIntValue h, Y.TyIntValue w]) [f, g, m]
-    X.ModMatMul h n w -> go03 $ \f g m -> Y.Call (Y.Function "jikka::modmat::mul" [Y.TyIntValue h, Y.TyIntValue n, Y.TyIntValue w]) [f, g, m]
-    X.ModMatPow n -> go03 $ \f k m -> Y.Call (Y.Function "jikka::modmat::pow" [Y.TyIntValue n]) [f, k, m]
+    X.ModNegate -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::mod::negate" []) [e1, e2]
+    X.ModPlus -> go03 $ \e1 e2 e3 -> Y.Call' (Y.Function "jikka::mod::plus" []) [e1, e2, e3]
+    X.ModMinus -> go03 $ \e1 e2 e3 -> Y.Call' (Y.Function "jikka::mod::minus" []) [e1, e2, e3]
+    X.ModMult -> go03 $ \e1 e2 e3 -> Y.Call' (Y.Function "jikka::mod::mult" []) [e1, e2, e3]
+    X.ModInv -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::mod::inv" []) [e1, e2]
+    X.ModPow -> go03 $ \e1 e2 e3 -> Y.Call' (Y.Function "jikka::mod::pow" []) [e1, e2, e3]
+    X.ModMatAp h w -> go03 $ \f x m -> Y.Call' (Y.Function "jikka::modmat::ap" [Y.TyIntValue h, Y.TyIntValue w]) [f, x, m]
+    X.ModMatAdd h w -> go03 $ \f g m -> Y.Call' (Y.Function "jikka::modmat::add" [Y.TyIntValue h, Y.TyIntValue w]) [f, g, m]
+    X.ModMatMul h n w -> go03 $ \f g m -> Y.Call' (Y.Function "jikka::modmat::mul" [Y.TyIntValue h, Y.TyIntValue n, Y.TyIntValue w]) [f, g, m]
+    X.ModMatPow n -> go03 $ \f k m -> Y.Call' (Y.Function "jikka::modmat::pow" [Y.TyIntValue n]) [f, k, m]
     -- list functions
     X.Cons -> go12' $ \t x xs -> do
       ys <- Y.newFreshName Y.LocalNameKind
@@ -361,7 +399,7 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
       useStatement $ Y.ForEach t x xs (body ++ [Y.If f [Y.callMethod' (Y.Var ys) "push_back" [Y.Var x]] Nothing])
       return $ Y.Var ys
     X.At -> go12 $ \_ e1 e2 -> Y.at e1 e2
-    X.SetAt -> go13 $ \t xs i x -> Y.Call (Y.SetAt t) [xs, i, x]
+    X.SetAt -> go13 $ \t xs i x -> Y.Call' (Y.SetAt t) [xs, i, x]
     X.Elem -> go12' $ \_ xs x -> do
       y <- Y.newFreshName Y.LocalNameKind
       useStatement $ Y.Declare Y.TyBool y (Y.DeclareCopy (Y.BinOp Y.NotEqual (Y.callFunction "std::find" [] [Y.begin xs, Y.end xs, x]) (Y.end xs)))
@@ -406,11 +444,15 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
       return $ Y.Var y
     X.Gcd1 -> go11' $ \t xs -> do
       y <- Y.newFreshName Y.LocalNameKind
-      useStatement $ Y.Declare t y (Y.DeclareCopy (Y.UnOp Y.Deref (Y.callFunction "std::accumulate" [] [Y.begin xs, Y.end xs, Y.litInt64 0, Y.Lam [(Y.TyAuto, Y.VarName "a"), (Y.TyAuto, Y.VarName "b")] Y.TyAuto [Y.Return $ Y.callFunction "std::gcd" [] [Y.Var $ Y.VarName "a", Y.Var $ Y.VarName "b"]]])))
+      a <- Y.newFreshName Y.LocalArgumentNameKind
+      b <- Y.newFreshName Y.LocalArgumentNameKind
+      useStatement $ Y.Declare t y (Y.DeclareCopy (Y.UnOp Y.Deref (Y.callFunction "std::accumulate" [] [Y.begin xs, Y.end xs, Y.litInt64 0, Y.Lam [(Y.TyAuto, a), (Y.TyAuto, b)] Y.TyAuto [Y.Return $ Y.callFunction "std::gcd" [] [Y.Var a, Y.Var b]]])))
       return $ Y.Var y
     X.Lcm1 -> go11' $ \t xs -> do
       y <- Y.newFreshName Y.LocalNameKind
-      useStatement $ Y.Declare t y (Y.DeclareCopy (Y.UnOp Y.Deref (Y.callFunction "std::accumulate" [] [Y.begin xs, Y.end xs, Y.litInt64 1, Y.Lam [(Y.TyAuto, Y.VarName "a"), (Y.TyAuto, Y.VarName "b")] Y.TyAuto [Y.Return $ Y.callFunction "std::lcm" [] [Y.Var $ Y.VarName "a", Y.Var $ Y.VarName "b"]]])))
+      a <- Y.newFreshName Y.LocalArgumentNameKind
+      b <- Y.newFreshName Y.LocalArgumentNameKind
+      useStatement $ Y.Declare t y (Y.DeclareCopy (Y.UnOp Y.Deref (Y.callFunction "std::accumulate" [] [Y.begin xs, Y.end xs, Y.litInt64 1, Y.Lam [(Y.TyAuto, a), (Y.TyAuto, b)] Y.TyAuto [Y.Return $ Y.callFunction "std::lcm" [] [Y.Var a, Y.Var b]]])))
       return $ Y.Var y
     X.All -> go01' $ \xs -> do
       y <- Y.newFreshName Y.LocalNameKind
@@ -430,7 +472,7 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
       useStatement $ Y.Declare (Y.TyVector t) ys (Y.DeclareCopy xs)
       useStatement $ Y.callFunction' "std::reverse" [] [Y.begin (Y.Var ys), Y.end (Y.Var ys)]
       return $ Y.Var ys
-    X.Range1 -> go01 $ \n -> Y.Call Y.Range [n]
+    X.Range1 -> go01 $ \n -> Y.Call' Y.Range [n]
     X.Range2 -> go02' $ \from to -> do
       ys <- Y.newFreshName Y.LocalNameKind
       useStatement $ Y.Declare (Y.TyVector Y.TyInt64) ys (Y.DeclareCopy (Y.vecCtor Y.TyInt64 [Y.BinOp Y.Sub to from]))
@@ -445,12 +487,12 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
     -- tuple functions
     X.Tuple -> goNN $ \ts es ->
       if Y.shouldBeArray ts
-        then Y.Call (Y.ArrayExt (head ts)) es
-        else Y.Call (Y.StdTuple ts) es
+        then Y.Call' (Y.ArrayExt (head ts)) es
+        else Y.Call' (Y.StdTuple ts) es
     X.Proj n -> goN1 $ \ts e ->
       if Y.shouldBeArray ts
         then Y.at e (Y.Lit (Y.LitInt32 n))
-        else Y.Call (Y.StdGet (toInteger n)) [e]
+        else Y.Call' (Y.StdGet (toInteger n)) [e]
     -- comparison
     X.LessThan -> go12 $ \_ e1 e2 -> Y.BinOp Y.LessThan e1 e2
     X.LessEqual -> go12 $ \_ e1 e2 -> Y.BinOp Y.LessEqual e1 e2
@@ -459,42 +501,42 @@ runAppBuiltin env f ts args = wrapError' ("converting builtin " ++ X.formatBuilt
     X.Equal -> go12 $ \_ e1 e2 -> Y.BinOp Y.Equal e1 e2
     X.NotEqual -> go12 $ \_ e1 e2 -> Y.BinOp Y.NotEqual e1 e2
     -- combinational functions
-    X.Fact -> go01 $ \e -> Y.Call (Y.Function "jikka::notmod::fact" []) [e]
-    X.Choose -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::notmod::choose" []) [e1, e2]
-    X.Permute -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::notmod::permute" []) [e1, e2]
-    X.MultiChoose -> go02 $ \e1 e2 -> Y.Call (Y.Function "jikka::notmod::multichoose" []) [e1, e2]
+    X.Fact -> go01 $ \e -> Y.Call' (Y.Function "jikka::notmod::fact" []) [e]
+    X.Choose -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::notmod::choose" []) [e1, e2]
+    X.Permute -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::notmod::permute" []) [e1, e2]
+    X.MultiChoose -> go02 $ \e1 e2 -> Y.Call' (Y.Function "jikka::notmod::multichoose" []) [e1, e2]
     -- data structures
-    X.ConvexHullTrickInit -> go00 $ Y.Call Y.ConvexHullTrickCtor []
-    X.ConvexHullTrickGetMin -> go02 $ \cht x -> Y.Call (Y.Method "get_min") [cht, x]
-    X.ConvexHullTrickInsert -> go03 $ \cht a b -> Y.Call Y.ConvexHullTrickCopyAddLine [cht, a, b]
-    X.SegmentTreeInitList semigrp -> go01 $ \a -> Y.Call (Y.SegmentTreeCtor (runSemigroup semigrp)) [a]
-    X.SegmentTreeGetRange _ -> go03 $ \segtree l r -> Y.Call (Y.Method "prod") [segtree, l, r]
-    X.SegmentTreeSetPoint semigrp -> go03 $ \segtree i a -> Y.Call (Y.SegmentTreeCopySetPoint (runSemigroup semigrp)) [segtree, i, a]
+    X.ConvexHullTrickInit -> go00 $ Y.Call' Y.ConvexHullTrickCtor []
+    X.ConvexHullTrickGetMin -> go02 $ \cht x -> Y.Call' (Y.Method "get_min") [cht, x]
+    X.ConvexHullTrickInsert -> go03 $ \cht a b -> Y.Call' Y.ConvexHullTrickCopyAddLine [cht, a, b]
+    X.SegmentTreeInitList semigrp -> go01 $ \a -> Y.Call' (Y.SegmentTreeCtor (runSemigroup semigrp)) [a]
+    X.SegmentTreeGetRange _ -> go03 $ \segtree l r -> Y.Call' (Y.Method "prod") [segtree, l, r]
+    X.SegmentTreeSetPoint semigrp -> go03 $ \segtree i a -> Y.Call' (Y.SegmentTreeCopySetPoint (runSemigroup semigrp)) [segtree, i, a]
 
 runExprFunction :: (MonadAlpha m, MonadError Error m) => Env -> X.Expr -> Y.Expr -> m ([Y.Statement], [Y.Statement], Y.Expr)
 runExprFunction env f e = case f of
   X.Lam x t body -> do
     y <- renameVarName' Y.LocalArgumentNameKind x
-    (stmts, body) <- runStatementsT $ runExpr ((x, t, y) : env) body
+    (stmts, body) <- runStatementsT $ runExpr (pushVar x t y env) body
     let stmts' = map (Y.replaceStatement y e) stmts
     let body' = Y.replaceExpr y e body
     return ([], stmts', body')
   f -> do
     (stmts, f) <- runStatementsT $ runExpr env f
-    return (stmts, [], Y.CallExpr f [e])
+    return (stmts, [], Y.Call f [e])
 
 runExprFunction2 :: (MonadAlpha m, MonadError Error m) => Env -> X.Expr -> Y.Expr -> Y.Expr -> m ([Y.Statement], [Y.Statement], Y.Expr)
 runExprFunction2 env f e1 e2 = case f of
   X.Lam2 x1 t1 x2 t2 body -> do
     y1 <- renameVarName' Y.LocalArgumentNameKind x1
     y2 <- renameVarName' Y.LocalArgumentNameKind x2
-    (stmts, body) <- runStatementsT $ runExpr ((x2, t2, y2) : (x1, t1, y1) : env) body
+    (stmts, body) <- runStatementsT $ runExpr (pushVar x2 t2 y2 (pushVar x1 t1 y1 env)) body
     let stmts' = map (Y.replaceStatement y2 e2 . Y.replaceStatement y1 e1) stmts
     let body' = Y.replaceExpr y2 e2 $ Y.replaceExpr y1 e1 body
     return ([], stmts', body')
   f -> do
     (stmts, f) <- runStatementsT $ runExpr env f
-    return (stmts, [], Y.CallExpr (Y.CallExpr f [e1]) [e2])
+    return (stmts, [], Y.Call (Y.Call f [e1]) [e2])
 
 runAssert :: (MonadStatements m, MonadAlpha m, MonadError Error m) => Env -> X.Expr -> m ()
 runAssert env = \case
@@ -514,8 +556,11 @@ runAssert env = \case
 runExpr :: (MonadStatements m, MonadAlpha m, MonadError Error m) => Env -> X.Expr -> m Y.Expr
 runExpr env = \case
   X.Var x -> do
-    y <- lookupVarName env x
-    return $ Y.Var y
+    case lookupVarName env x of
+      Right y -> return $ Y.Var y
+      Left _ -> case lookupFunName env x of
+        Right f -> return $ Y.Callable (Y.Function f [])
+        Left _ -> throwInternalError $ "undefined variable: " ++ X.formatVarName x
   X.Lit lit -> do
     runLiteral env lit
   e@(X.App _ _) -> do
@@ -540,15 +585,15 @@ runExpr env = \case
               else do
                 args' <- mapM (runExpr env) (drop arity args)
                 e <- runAppBuiltin env builtin bts (take arity args)
-                return $ Y.CallExpr e args'
+                return $ Y.Call e args'
       _ -> do
         f <- runExpr env f
         args <- mapM (runExpr env) args
-        return $ Y.CallExpr f args
+        return $ Y.Call f args
   e@(X.Lam _ _ _) -> do
     let (args, body) = X.uncurryLam e
     ys <- mapM (renameVarName' Y.LocalArgumentNameKind . fst) args
-    let env' = reverse (zipWith (\(x, t) y -> (x, t, y)) args ys) ++ env
+    let env' = foldl (\env ((x, t), y) -> pushVar x t y env) env (zip args ys)
     ret <- runType =<< typecheckExpr env' body
     (stmts, body) <- runStatementsT $ runExpr env' body
     ts <- mapM (runType . snd) args
@@ -559,18 +604,18 @@ runExpr env = \case
     t' <- runType t
     e1 <- runExpr env e1
     useStatement $ Y.Declare t' y (Y.DeclareCopy e1)
-    runExpr ((x, t, y) : env) e2
+    runExpr (pushVar x t y env) e2
   X.Assert e1 e2 -> do
     runAssert env e1
     runExpr env e2
 
-runToplevelFunDef :: (MonadAlpha m, MonadError Error m) => Env -> Y.VarName -> [(X.VarName, X.Type)] -> X.Type -> X.Expr -> m [Y.ToplevelStatement]
+runToplevelFunDef :: (MonadAlpha m, MonadError Error m) => Env -> Y.FunName -> [(X.VarName, X.Type)] -> X.Type -> X.Expr -> m [Y.ToplevelStatement]
 runToplevelFunDef env f args ret body = do
   ret <- runType ret
   args <- forM args $ \(x, t) -> do
     y <- renameVarName' Y.ArgumentNameKind x
     return (x, t, y)
-  (stmts, result) <- runStatementsT $ runExpr (reverse args ++ env) body
+  (stmts, result) <- runStatementsT $ runExpr (foldl (\env (x, t, y) -> pushVar x t y env) env args) body
   args <- forM args $ \(_, t, y) -> do
     t <- runType t
     return (t, y)
@@ -582,7 +627,7 @@ runToplevelVarDef env x t e = do
   (stmts, e) <- runStatementsT $ runExpr env e
   case stmts of
     [] -> return [Y.VarDef t x e]
-    _ -> return [Y.VarDef t x (Y.CallExpr (Y.Lam [] t (stmts ++ [Y.Return e])) [])]
+    _ -> return [Y.VarDef t x (Y.Call (Y.Lam [] t (stmts ++ [Y.Return e])) [])]
 
 runToplevelExpr :: (MonadAlpha m, MonadError Error m) => Env -> X.ToplevelExpr -> m [Y.ToplevelStatement]
 runToplevelExpr env = \case
@@ -593,7 +638,7 @@ runToplevelExpr env = \case
       _ -> throwInternalError "solve function must be a function" -- TODO: add check in restricted Python
     ret <- runType ret
     -- do eta-expansion to define it as a function.
-    e <- X.etaExpand (map (\(x, t, _) -> (x, t)) env) e
+    e <- X.etaExpand (typeEnv env) e
     (args, body) <- case X.uncurryLam e of
       (args, body) | length args == length ts -> return (args, body)
       _ -> throwInternalError "the result expr must be eta-converted"
@@ -601,16 +646,16 @@ runToplevelExpr env = \case
     args <- forM args $ \(x, t) -> do
       y <- renameVarName' Y.ArgumentNameKind x
       return (x, t, y)
-    (stmts, e) <- runStatementsT $ runExpr (reverse args ++ env) body
+    (stmts, e) <- runStatementsT $ runExpr (foldl (\env (x, t, y) -> pushVar x t y env) env args) body
     let body = stmts ++ [Y.Return e]
     args' <- forM args $ \(_, t, y) -> do
       t <- runType t
       return (t, y)
-    let f = Y.VarName "solve"
+    let f = Y.FunName "solve"
     return [Y.FunDef ret f args' body]
   X.ToplevelLet x t e cont -> case (X.uncurryLam e, X.uncurryFunTy t) of
     ((args@(_ : _), body), (ts@(_ : _), ret)) -> do
-      g <- renameVarName' Y.FunctionNameKind x
+      g <- renameFunName' x
       (args, body) <-
         if length args < length ts
           then do
@@ -619,28 +664,28 @@ runToplevelExpr env = \case
             let body' = X.uncurryApp body (map X.Var xs)
             return (args', body')
           else return (args, body)
-      stmt <- runToplevelFunDef ((x, t, g) : env) g args ret body
-      cont <- runToplevelExpr ((x, t, g) : env) cont
+      stmt <- runToplevelFunDef (pushFun x t g env) g args ret body
+      cont <- runToplevelExpr (pushFun x t g env) cont
       return $ stmt ++ cont
     _ -> do
       y <- renameVarName' Y.ConstantNameKind x
       stmt <- runToplevelVarDef env y t e
-      cont <- runToplevelExpr ((x, t, y) : env) cont
+      cont <- runToplevelExpr (pushVar x t y env) cont
       return $ stmt ++ cont
   X.ToplevelLetRec f args ret body cont -> do
-    g <- renameVarName' Y.FunctionNameKind f
+    g <- renameFunName' f
     let t = X.curryFunTy (map snd args) ret
-    stmt <- runToplevelFunDef ((f, t, g) : env) g args ret body
-    cont <- runToplevelExpr ((f, t, g) : env) cont
+    stmt <- runToplevelFunDef (pushFun f t g env) g args ret body
+    cont <- runToplevelExpr (pushFun f t g env) cont
     return $ stmt ++ cont
   X.ToplevelAssert e cont -> do
     (stmts, e) <- runStatementsT $ runExpr env e
-    let stmt = Y.StaticAssert (Y.CallExpr (Y.Lam [] Y.TyBool (stmts ++ [Y.Return e])) []) ""
+    let stmt = Y.StaticAssert (Y.Call (Y.Lam [] Y.TyBool (stmts ++ [Y.Return e])) []) ""
     cont <- runToplevelExpr env cont
     return $ stmt : cont
 
 runProgram :: (MonadAlpha m, MonadError Error m) => X.Program -> m Y.Program
-runProgram prog = Y.Program <$> runToplevelExpr [] prog
+runProgram prog = Y.Program <$> runToplevelExpr emptyEnv prog
 
 run :: (MonadAlpha m, MonadError Error m) => X.Program -> m Y.Program
 run prog = wrapError' "Jikka.CPlusPlus.Convert.FromCore" $ do

--- a/src/Jikka/CPlusPlus/Convert/InlineSetAt.hs
+++ b/src/Jikka/CPlusPlus/Convert/InlineSetAt.hs
@@ -24,8 +24,8 @@ runExpr :: (MonadAlpha m, MonadWriter [Statement] m) => Expr -> m Expr
 runExpr = \case
   Call' (SetAt t) [xs, i, x] -> do
     y <- case xs of
-      Var xs -> renameVarName LocalNameKind xs
-      _ -> newFreshName LocalNameKind
+      Var xs -> renameVarName LocalNameHint xs
+      _ -> newFreshName LocalNameHint
     tell
       [ Declare (TyVector t) y (DeclareCopy xs),
         Assign (AssignExpr SimpleAssign (LeftAt (LeftVar y) i) x)

--- a/src/Jikka/CPlusPlus/Convert/InlineSetAt.hs
+++ b/src/Jikka/CPlusPlus/Convert/InlineSetAt.hs
@@ -22,9 +22,9 @@ import Jikka.Common.Error
 
 runExpr :: (MonadAlpha m, MonadWriter [Statement] m) => Expr -> m Expr
 runExpr = \case
-  Call (SetAt t) [xs, i, x] -> do
+  Call' (SetAt t) [xs, i, x] -> do
     y <- case xs of
-      Var (VarName xs) -> renameVarName LocalNameKind xs
+      Var xs -> renameVarName LocalNameKind xs
       _ -> newFreshName LocalNameKind
     tell
       [ Declare (TyVector t) y (DeclareCopy xs),

--- a/src/Jikka/CPlusPlus/Convert/OptimizeRange.hs
+++ b/src/Jikka/CPlusPlus/Convert/OptimizeRange.hs
@@ -20,13 +20,13 @@ import Jikka.Common.Error
 
 runExpr :: Monad m => Expr -> m Expr
 runExpr = \case
-  Call At [Call Range [_], i] -> return i
-  Call MethodSize [Call Range [n]] -> return n
+  Call' At [Call' Range [_], i] -> return i
+  Call' MethodSize [Call' Range [n]] -> return n
   e -> return e
 
 runStatement :: Monad m => Statement -> m Statement
 runStatement = \case
-  ForEach _ x (Call Range [n]) body -> return $ repStatement x n body -- TODO: check n is not updated in body
+  ForEach _ x (Call' Range [n]) body -> return $ repStatement x n body -- TODO: check n is not updated in body
   stmt -> return stmt
 
 runProgram :: Monad m => Program -> m Program

--- a/src/Jikka/CPlusPlus/Convert/UnpackTuples.hs
+++ b/src/Jikka/CPlusPlus/Convert/UnpackTuples.hs
@@ -146,13 +146,13 @@ runStatement stmt cont = case stmt of
     case init of
       -- std::tuple<T1, T2, ...> x = std::tuple<...>(e1, e2, ...);
       DeclareCopy (Call' (StdTuple ts) es) -> do
-        ys <- replicateM (length es) (renameVarName LocalNameKind x)
+        ys <- replicateM (length es) (renameVarName LocalNameHint x)
         modify' (M.insert x (zip ts ys))
         return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts ys es
       -- std::array<T, n> x = std::array<T, n>{e1, e2, ...};
       DeclareCopy (Call' (ArrayExt t) es) -> do
         let ts = replicate (length es) t
-        ys <- replicateM (length es) (renameVarName LocalNameKind x)
+        ys <- replicateM (length es) (renameVarName LocalNameHint x)
         modify' (M.insert x (zip ts ys))
         return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts ys es
       _ -> do
@@ -177,7 +177,7 @@ runStatement stmt cont = case stmt of
                     if shouldBeArray ts
                       then map (\i -> Call' At [e, litInt32 i]) [0 .. n - 1]
                       else map (\i -> Call' (StdGet i) [e]) [0 .. n - 1]
-            tmpys <- replicateM (length ts) (newFreshName LocalNameKind)
+            tmpys <- replicateM (length ts) (newFreshName LocalNameHint)
             return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts tmpys es ++ zipWith (\y e -> Assign (AssignExpr SimpleAssign (LeftVar y) (Var e))) (map snd ys) tmpys
           Nothing -> return [Assign (AssignExpr SimpleAssign (LeftVar x) e)]
       _ -> do

--- a/src/Jikka/CPlusPlus/Convert/UnpackTuples.hs
+++ b/src/Jikka/CPlusPlus/Convert/UnpackTuples.hs
@@ -34,17 +34,19 @@ runExpr = \case
          in if shouldBeArray (map fst ys)
               then
                 let t = fst (head ys)
-                 in Call (ArrayExt t) es
+                 in Call' (ArrayExt t) es
               else
                 let ts = map fst ys
-                 in Call (StdTuple ts) es
+                 in Call' (StdTuple ts) es
   Lit lit -> return $ Lit lit
   UnOp op e -> UnOp op <$> runExpr e
   BinOp op e1 e2 -> BinOp op <$> runExpr e1 <*> runExpr e2
   Cond e1 e2 e3 -> Cond <$> runExpr e1 <*> runExpr e2 <*> runExpr e3
   Lam args ret body -> Lam args ret <$> runStatements body []
-  Call f args -> runCall f args
-  CallExpr e args -> CallExpr <$> runExpr e <*> mapM runExpr args
+  Call f args -> case f of
+    Callable f -> runCall f args
+    _ -> Call <$> runExpr f <*> mapM runExpr args
+  Callable f -> return $ Callable f
 
 -- | `runCall` does the same thing to `runExpr` and also reduces `std::get<i>(e)` and `e[i]`.
 runCall :: (MonadAlpha m, MonadError Error m, MonadState (M.Map VarName [(Type, VarName)]) m) => Function -> [Expr] -> m Expr
@@ -60,9 +62,9 @@ runCall f args = do
           when (n < 0 || toInteger (length ys) <= n) $ do
             throwInternalError "index out of range"
           return $ es !! fromInteger n
-        Nothing -> return $ Call f args
+        Nothing -> return $ Call' f args
     -- std::get<n>(std::tuple<T1, T2, ...>(e1, e2, ...))
-    (StdGet n, [Call (StdTuple _) es]) -> do
+    (StdGet n, [Call' (StdTuple _) es]) -> do
       when (n < 0 || toInteger (length es) <= n) $ do
         throwInternalError "index out of range"
       return $ es !! fromInteger n
@@ -81,10 +83,10 @@ runCall f args = do
               when (n < 0 || toInteger (length ys) <= n) $ do
                 throwInternalError "index out of range"
               return (es !! fromInteger n)
-            Nothing -> return $ Call f args
-        Nothing -> return $ Call f args
+            Nothing -> return $ Call' f args
+        Nothing -> return $ Call' f args
     -- (std::array<T, n>{e1, e2, ...})[i]
-    (At, [Call (ArrayExt _) es, e2]) -> do
+    (At, [Call' (ArrayExt _) es, e2]) -> do
       let n = case e2 of
             Lit (LitInt32 n) -> Just n
             Lit (LitInt64 n) -> Just n
@@ -94,8 +96,8 @@ runCall f args = do
           when (n < 0 || toInteger (length es) <= n) $ do
             throwInternalError "index out of range"
           return (es !! fromInteger n)
-        Nothing -> return $ Call f args
-    _ -> return $ Call f args
+        Nothing -> return $ Call' f args
+    _ -> return $ Call' f args
 
 runLeftExpr :: (MonadAlpha m, MonadError Error m, MonadState (M.Map VarName [(Type, VarName)]) m) => LeftExpr -> m LeftExpr
 runLeftExpr = \case
@@ -143,14 +145,14 @@ runStatement stmt cont = case stmt of
       DeclareInitialize es -> DeclareInitialize <$> mapM runExpr es
     case init of
       -- std::tuple<T1, T2, ...> x = std::tuple<...>(e1, e2, ...);
-      DeclareCopy (Call (StdTuple ts) es) -> do
-        ys <- replicateM (length es) (renameVarName LocalNameKind (unVarName x))
+      DeclareCopy (Call' (StdTuple ts) es) -> do
+        ys <- replicateM (length es) (renameVarName LocalNameKind x)
         modify' (M.insert x (zip ts ys))
         return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts ys es
       -- std::array<T, n> x = std::array<T, n>{e1, e2, ...};
-      DeclareCopy (Call (ArrayExt t) es) -> do
+      DeclareCopy (Call' (ArrayExt t) es) -> do
         let ts = replicate (length es) t
-        ys <- replicateM (length es) (renameVarName LocalNameKind (unVarName x))
+        ys <- replicateM (length es) (renameVarName LocalNameKind x)
         modify' (M.insert x (zip ts ys))
         return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts ys es
       _ -> do
@@ -169,12 +171,12 @@ runStatement stmt cont = case stmt of
             let ts = map fst ys
             let n = toInteger (length ts)
             let es = case e of
-                  Call (StdTuple _) es -> es
-                  Call (ArrayExt _) es -> es
+                  Call' (StdTuple _) es -> es
+                  Call' (ArrayExt _) es -> es
                   _ ->
                     if shouldBeArray ts
-                      then map (\i -> Call At [e, litInt32 i]) [0 .. n - 1]
-                      else map (\i -> Call (StdGet i) [e]) [0 .. n - 1]
+                      then map (\i -> Call' At [e, litInt32 i]) [0 .. n - 1]
+                      else map (\i -> Call' (StdGet i) [e]) [0 .. n - 1]
             tmpys <- replicateM (length ts) (newFreshName LocalNameKind)
             return $ zipWith3 (\t y e -> Declare t y (DeclareCopy e)) ts tmpys es ++ zipWith (\y e -> Assign (AssignExpr SimpleAssign (LeftVar y) (Var e))) (map snd ys) tmpys
           Nothing -> return [Assign (AssignExpr SimpleAssign (LeftVar x) e)]
@@ -182,7 +184,7 @@ runStatement stmt cont = case stmt of
         forM_ (S.toList (freeVarsAssignExpr e)) $ \x -> do
           ys <- gets (M.lookup x)
           case ys of
-            Just _ -> throwInternalError $ "wrong assignment to a tuple: " ++ unVarName x
+            Just _ -> throwInternalError $ "wrong assignment to a tuple: " ++ formatVarName x
             Nothing -> return ()
         return [Assign e]
   Assert e -> do

--- a/src/Jikka/CPlusPlus/Convert/UseInitialization.hs
+++ b/src/Jikka/CPlusPlus/Convert/UseInitialization.hs
@@ -22,10 +22,10 @@ import Jikka.Common.Error
 runStatement :: Statement -> Statement
 runStatement = \case
   Declare t x init -> case (t, init) of
-    (TyVector _, DeclareCopy (Call (VecCtor _) [])) -> Declare t x DeclareDefault
-    (TyVector _, DeclareCopy (Call (VecCtor _) es)) -> Declare t x (DeclareInitialize es)
-    (TyConvexHullTrick, DeclareCopy (Call ConvexHullTrickCtor es)) -> Declare t x (DeclareInitialize es)
-    (TySegmentTree _, DeclareCopy (Call (SegmentTreeCtor _) es)) -> Declare t x (DeclareInitialize es)
+    (TyVector _, DeclareCopy (Call' (VecCtor _) [])) -> Declare t x DeclareDefault
+    (TyVector _, DeclareCopy (Call' (VecCtor _) es)) -> Declare t x (DeclareInitialize es)
+    (TyConvexHullTrick, DeclareCopy (Call' ConvexHullTrickCtor es)) -> Declare t x (DeclareInitialize es)
+    (TySegmentTree _, DeclareCopy (Call' (SegmentTreeCtor _) es)) -> Declare t x (DeclareInitialize es)
     (_, _) -> Declare t x init
   stmt -> stmt
 

--- a/src/Jikka/CPlusPlus/Language/Expr.hs
+++ b/src/Jikka/CPlusPlus/Language/Expr.hs
@@ -21,6 +21,7 @@ data NameHint
   | ConstantNameHint
   | FunctionNameHint
   | ArgumentNameHint
+  | AdHocNameHint String
   deriving (Eq, Ord, Show, Read)
 
 data VarName = VarName OccName NameFlavour (Maybe NameHint) deriving (Eq, Ord, Show, Read)

--- a/src/Jikka/CPlusPlus/Language/Expr.hs
+++ b/src/Jikka/CPlusPlus/Language/Expr.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- |
 -- Module      : Jikka.CPlusPlus.Language.Expr
 -- Description : contains data types of C++ language. / C++ のためのデータ型を含みます。
@@ -13,11 +11,35 @@
 -- The data types are intended to use for the code generation.
 module Jikka.CPlusPlus.Language.Expr where
 
-import Data.String (IsString)
+import Data.String
+import Jikka.Common.Name
 
-newtype VarName = VarName {unVarName :: String} deriving (Eq, Ord, Show, Read, IsString)
+data NameKind
+  = LocalNameKind
+  | LocalArgumentNameKind
+  | LoopCounterNameKind
+  | ConstantNameKind
+  | FunctionNameKind
+  | ArgumentNameKind
+  deriving (Eq, Ord, Show, Read)
 
-newtype FunName = FunName {unFunName :: String} deriving (Eq, Ord, Show, Read, IsString)
+data VarName = VarName OccName NameFlavour (Maybe NameKind) deriving (Eq, Ord, Show, Read)
+
+instance IsString VarName where
+  fromString s =
+    let (occ, flavour) = toFlavouredName s
+     in VarName occ flavour Nothing
+
+formatVarName :: VarName -> String
+formatVarName (VarName occ flavour _) = formatFlavouredName occ flavour
+
+newtype FunName = FunName String deriving (Eq, Ord, Show, Read)
+
+instance IsString FunName where
+  fromString = FunName
+
+formatFunName :: FunName -> String
+formatFunName (FunName occ) = occ
 
 data Type
   = -- | @auto@
@@ -192,10 +214,9 @@ data Expr
     Cond Expr Expr Expr
   | -- | lambda expression @[=](T1 x1, T2 x2, ...) -> Tr { stmt1; stmt2; ... }@
     Lam [(Type, VarName)] Type [Statement]
-  | -- | @f(e1, e2, ...)@ for a fixed function @f@
-    Call Function [Expr]
-  | -- | @e(e1, e2, ...)@ for an callable expr @e@
-    CallExpr Expr [Expr]
+  | -- | @f(e1, e2, ...)@ for a callable @f@
+    Call Expr [Expr]
+  | Callable Function
   deriving (Eq, Ord, Show, Read)
 
 data LeftExpr
@@ -254,7 +275,7 @@ data ToplevelStatement
   = -- | @const T x = e;@
     VarDef Type VarName Expr
   | -- | @T f(T1 x1, T2 x2, ...) { stmt1; stmt2; ... }@
-    FunDef Type VarName [(Type, VarName)] [Statement]
+    FunDef Type FunName [(Type, VarName)] [Statement]
   | -- | @static_assert(e, msg);@
     StaticAssert Expr String
   deriving (Eq, Ord, Show, Read)

--- a/src/Jikka/CPlusPlus/Language/Expr.hs
+++ b/src/Jikka/CPlusPlus/Language/Expr.hs
@@ -14,16 +14,16 @@ module Jikka.CPlusPlus.Language.Expr where
 import Data.String
 import Jikka.Common.Name
 
-data NameKind
-  = LocalNameKind
-  | LocalArgumentNameKind
-  | LoopCounterNameKind
-  | ConstantNameKind
-  | FunctionNameKind
-  | ArgumentNameKind
+data NameHint
+  = LocalNameHint
+  | LocalArgumentNameHint
+  | LoopCounterNameHint
+  | ConstantNameHint
+  | FunctionNameHint
+  | ArgumentNameHint
   deriving (Eq, Ord, Show, Read)
 
-data VarName = VarName OccName NameFlavour (Maybe NameKind) deriving (Eq, Ord, Show, Read)
+data VarName = VarName OccName NameFlavour (Maybe NameHint) deriving (Eq, Ord, Show, Read)
 
 instance IsString VarName where
   fromString s =

--- a/src/Jikka/CPlusPlus/Language/Util.hs
+++ b/src/Jikka/CPlusPlus/Language/Util.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Jikka.CPlusPlus.Language.Util where
 
 import Control.Monad.Identity
-import Data.Char (isAlphaNum, isNumber)
 import qualified Data.Set as S
 import Jikka.CPlusPlus.Language.Expr
 import Jikka.Common.Alpha
@@ -12,38 +12,23 @@ import Jikka.Common.Alpha
 fromLeftExpr :: LeftExpr -> Expr
 fromLeftExpr = \case
   LeftVar x -> Var x
-  LeftAt x e -> Call At [fromLeftExpr x, e]
-  LeftGet n e -> Call (Function "std::get" [TyIntValue n]) [fromLeftExpr e]
-
-data NameKind
-  = LocalNameKind
-  | LocalArgumentNameKind
-  | LoopCounterNameKind
-  | ConstantNameKind
-  | FunctionNameKind
-  | ArgumentNameKind
-  deriving (Eq, Ord, Show, Read)
-
-fromNameKind :: NameKind -> String
-fromNameKind = \case
-  LocalNameKind -> "x"
-  LocalArgumentNameKind -> "b"
-  LoopCounterNameKind -> "i"
-  ConstantNameKind -> "c"
-  FunctionNameKind -> "f"
-  ArgumentNameKind -> "a"
+  LeftAt x e -> Call' At [fromLeftExpr x, e]
+  LeftGet n e -> Call' (Function "std::get" [TyIntValue n]) [fromLeftExpr e]
 
 newFreshName :: MonadAlpha m => NameKind -> m VarName
-newFreshName kind = renameVarName kind ""
-
-renameVarName :: MonadAlpha m => NameKind -> String -> m VarName
-renameVarName kind hint = do
+newFreshName kind = do
   i <- nextCounter
-  let f = reverse . dropWhile (\c -> isNumber c || c == '_') . reverse . takeWhile (\c -> isAlphaNum c || c == '_')
-  let prefix = case f hint of
-        "" -> fromNameKind kind
-        hint' -> hint' ++ "_"
-  return (VarName (prefix ++ show i))
+  return (VarName Nothing (Just i) (Just kind))
+
+renameVarName :: MonadAlpha m => NameKind -> VarName -> m VarName
+renameVarName kind (VarName occ _ _) = case occ of
+  Nothing -> newFreshName kind
+  Just occ -> renameVarName' kind occ
+
+renameVarName' :: MonadAlpha m => NameKind -> String -> m VarName
+renameVarName' kind occ = do
+  i <- nextCounter
+  return (VarName (Just occ) (Just i) (Just kind))
 
 freeVars :: Expr -> S.Set VarName
 freeVars = \case
@@ -53,8 +38,8 @@ freeVars = \case
   BinOp _ e1 e2 -> freeVars e1 <> freeVars e2
   Cond e1 e2 e3 -> freeVars e1 <> freeVars e2 <> freeVars e3
   Lam args _ body -> freeVarsStatements body S.\\ S.fromList (map snd args)
-  Call _ args -> mconcat (map freeVars args)
-  CallExpr f args -> freeVars f <> mconcat (map freeVars args)
+  Call f args -> freeVars f <> mconcat (map freeVars args)
+  Callable _ -> S.empty
 
 freeVarsStatements :: [Statement] -> S.Set VarName
 freeVarsStatements = mconcat . map freeVarsStatement
@@ -112,14 +97,17 @@ litInt32 n = Lit (LitInt32 n)
 incrExpr :: Expr -> Expr
 incrExpr e = BinOp Add e (Lit (LitInt32 1))
 
+pattern Call' :: Function -> [Expr] -> Expr
+pattern Call' f args = Call (Callable f) args
+
 size :: Expr -> Expr
-size e = Call MethodSize [e]
+size e = Call' MethodSize [e]
 
 at :: Expr -> Expr -> Expr
-at e i = Call At [e, i]
+at e i = Call' At [e, i]
 
 cast :: Type -> Expr -> Expr
-cast t e = Call (Cast t) [e]
+cast t e = Call' (Cast t) [e]
 
 assignSimple :: VarName -> Expr -> Statement
 assignSimple x e = Assign (AssignExpr SimpleAssign (LeftVar x) e)
@@ -128,25 +116,25 @@ assignAt :: VarName -> Expr -> Expr -> Statement
 assignAt xs i e = Assign (AssignExpr SimpleAssign (LeftAt (LeftVar xs) i) e)
 
 callFunction :: FunName -> [Type] -> [Expr] -> Expr
-callFunction f ts args = Call (Function f ts) args
+callFunction f ts args = Call' (Function f ts) args
 
 callFunction' :: FunName -> [Type] -> [Expr] -> Statement
 callFunction' = ((ExprStatement .) .) . callFunction
 
 callMethod :: Expr -> FunName -> [Expr] -> Expr
-callMethod e f args = Call (Method f) (e : args)
+callMethod e f args = Call' (Method f) (e : args)
 
 callMethod' :: Expr -> FunName -> [Expr] -> Statement
 callMethod' = ((ExprStatement .) .) . callMethod
 
 vecCtor :: Type -> [Expr] -> Expr
-vecCtor t es = Call (VecCtor t) es
+vecCtor t es = Call' (VecCtor t) es
 
 begin :: Expr -> Expr
-begin e = Call (Method "begin") [e]
+begin e = Call' (Method "begin") [e]
 
 end :: Expr -> Expr
-end e = Call (Method "end") [e]
+end e = Call' (Method "end") [e]
 
 mapExprStatementExprM :: Monad m => (Expr -> m Expr) -> (Statement -> m [Statement]) -> Expr -> m Expr
 mapExprStatementExprM f g = go
@@ -158,8 +146,8 @@ mapExprStatementExprM f g = go
       BinOp op e1 e2 -> f =<< (BinOp op <$> go e1 <*> go e2)
       Cond e1 e2 e3 -> f =<< (Cond <$> go e1 <*> go e2 <*> go e3)
       Lam args ret body -> f . Lam args ret . concat =<< mapM (mapExprStatementStatementM f g) body
-      Call g args -> f . Call g =<< mapM go args
-      CallExpr g args -> f =<< (CallExpr <$> go g <*> mapM go args)
+      Call g args -> f =<< (Call <$> go g <*> mapM go args)
+      Callable g -> f $ Callable g
 
 mapExprStatementLeftExprM :: Monad m => (Expr -> m Expr) -> (Statement -> m [Statement]) -> LeftExpr -> m LeftExpr
 mapExprStatementLeftExprM f g = \case
@@ -255,3 +243,6 @@ replaceStatement x e = head . runIdentity . mapExprStatementStatementM go (retur
     go = \case
       Var y | y == x -> return e
       e' -> return e'
+
+mapToplevelStatementProgramM :: Monad m => (ToplevelStatement -> m [ToplevelStatement]) -> Program -> m Program
+mapToplevelStatementProgramM f prog = Program . concat <$> mapM f (decls prog)

--- a/src/Jikka/CPlusPlus/Language/Util.hs
+++ b/src/Jikka/CPlusPlus/Language/Util.hs
@@ -15,17 +15,17 @@ fromLeftExpr = \case
   LeftAt x e -> Call' At [fromLeftExpr x, e]
   LeftGet n e -> Call' (Function "std::get" [TyIntValue n]) [fromLeftExpr e]
 
-newFreshName :: MonadAlpha m => NameKind -> m VarName
+newFreshName :: MonadAlpha m => NameHint -> m VarName
 newFreshName kind = do
   i <- nextCounter
   return (VarName Nothing (Just i) (Just kind))
 
-renameVarName :: MonadAlpha m => NameKind -> VarName -> m VarName
+renameVarName :: MonadAlpha m => NameHint -> VarName -> m VarName
 renameVarName kind (VarName occ _ _) = case occ of
   Nothing -> newFreshName kind
   Just occ -> renameVarName' kind occ
 
-renameVarName' :: MonadAlpha m => NameKind -> String -> m VarName
+renameVarName' :: MonadAlpha m => NameHint -> String -> m VarName
 renameVarName' kind occ = do
   i <- nextCounter
   return (VarName (Just occ) (Just i) (Just kind))

--- a/src/Jikka/CPlusPlus/Language/VariableAnalysis.hs
+++ b/src/Jikka/CPlusPlus/Language/VariableAnalysis.hs
@@ -34,8 +34,8 @@ analyzeExpr = \case
     let ReadWriteList rs ws = analyzeStatements body
         args' = S.fromList (map snd args)
      in ReadWriteList (rs `S.difference` args') (ws `S.difference` args')
-  Call _ args -> mconcat (map analyzeExpr args)
-  CallExpr f args -> mconcat (map analyzeExpr (f : args))
+  Call f args -> mconcat (map analyzeExpr (f : args))
+  Callable _ -> mempty
 
 analyzeLeftExpr :: LeftExpr -> ReadWriteList
 analyzeLeftExpr = \case

--- a/src/Jikka/Common/Name.hs
+++ b/src/Jikka/Common/Name.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Jikka.Common.Name where
+
+import Data.List
+import Data.Maybe
+import Text.Read
+
+type OccName = Maybe String
+
+type NameFlavour = Maybe Int
+
+toFlavouredName :: String -> (OccName, NameFlavour)
+toFlavouredName = \case
+  "_" -> (Nothing, Nothing)
+  s -> case elemIndex '$' s of
+    Nothing -> (Just s, Nothing)
+    Just i ->
+      let (occ, flavour) = splitAt i s
+          occ' = if occ == "" then Nothing else Just occ
+          flavour' = case readMaybe (tail flavour) of
+            Nothing -> error $ "Jikka.Common.Name.toFlavouredName: invalid flavoured name: " ++ s
+            Just i -> i
+       in (occ', Just flavour')
+
+formatFlavouredName :: OccName -> NameFlavour -> String
+formatFlavouredName occ flavour = case (occ, flavour) of
+  (Nothing, Nothing) -> "_"
+  _ -> fromMaybe "" occ ++ maybe "" (('$' :) . show) flavour

--- a/src/Jikka/Core/Convert/Alpha.hs
+++ b/src/Jikka/Core/Convert/Alpha.hs
@@ -35,16 +35,15 @@ rename x = do
     if x `notElem` used
       then return x
       else do
-        let base = takeWhile (/= '$') (unVarName x)
-        i <- nextCounter
-        return $ VarName (base ++ "$" ++ show i)
+        let base = takeWhile (/= '$') (formatVarName x)
+        VarName (Just base) . Just <$> nextCounter
   put $ y : used
   return y
 
 runExpr' :: (MonadState UsedVars m, MonadAlpha m, MonadError Error m) => RenameMapping -> Expr -> m Expr
 runExpr' env = \case
   Var x -> case lookup x env of
-    Nothing -> throwInternalError $ "undefined variable: " ++ unVarName x
+    Nothing -> throwInternalError $ "undefined variable: " ++ formatVarName x
     Just y -> return $ Var y
   Lit lit -> return $ Lit lit
   App f e -> App <$> runExpr' env f <*> runExpr' env e

--- a/src/Jikka/Core/Convert/SegmentTree.hs
+++ b/src/Jikka/Core/Convert/SegmentTree.hs
@@ -52,8 +52,8 @@ pattern CumulativeSum t f e es <-
     )
   where
     CumulativeSum t f e es =
-      let x1 = findUnusedVarName (VarName "y") f
-          x2 = findUnusedVarName (VarName "x") f
+      let x1 = findUnusedVarName' f
+          x2 = findUnusedVarName' f
        in Scanl' t t (Lam2 x1 t x2 t (App (App f (Var x1)) (Var x2))) e es
 
 pattern CumulativeSumFlip t f e es <-
@@ -65,8 +65,8 @@ pattern CumulativeSumFlip t f e es <-
     )
   where
     CumulativeSumFlip t f e es =
-      let x1 = findUnusedVarName (VarName "y") f
-          x2 = findUnusedVarName (VarName "x") f
+      let x1 = findUnusedVarName' f
+          x2 = findUnusedVarName' f
        in Scanl' t t (Lam2 x1 t x2 t (App (App f (Var x2)) (Var x1))) e es
 
 builtinToSemigroup :: Builtin -> [Type] -> Maybe Semigroup'

--- a/src/Jikka/Core/Convert/TypeInfer.hs
+++ b/src/Jikka/Core/Convert/TypeInfer.hs
@@ -66,7 +66,7 @@ wrapHint hint = censor (fmap (map (consHint hint)))
 
 wrapErrorFromHint :: MonadError Error m => Hint -> m a -> m a
 wrapErrorFromHint = \case
-  VarHint x -> wrapError' $ "around variable " ++ unVarName x
+  VarHint x -> wrapError' $ "around variable " ++ formatVarName x
   ExprHint e -> wrapError' $ "around expr " ++ summarize (formatExpr e)
   ToplevelExprHint e -> wrapError' $ "around toplevel expr " ++ summarize (formatToplevelExpr e)
   where
@@ -170,7 +170,7 @@ subst sigma = \case
 unifyTyVar :: (MonadState Subst m, MonadError Error m) => TypeName -> Type -> m ()
 unifyTyVar x t =
   if x `elem` freeTyVars t
-    then throwInternalError $ "looped type equation " ++ unTypeName x ++ " = " ++ formatType t
+    then throwInternalError $ "looped type equation " ++ formatTypeName x ++ " = " ++ formatType t
     else do
       modify' (Subst . M.insert x t . unSubst) -- This doesn't introduce the loop.
 

--- a/src/Jikka/Core/Evaluate.hs
+++ b/src/Jikka/Core/Evaluate.hs
@@ -259,10 +259,10 @@ callBuiltin builtin ts args = wrapError' ("while calling builtin " ++ formatBuil
     SegmentTreeSetPoint _ -> go3' valueToList valueToInt pure ValList setAtEither
 
 callLambda :: MonadError Error m => Maybe VarName -> Env -> VarName -> Type -> Expr -> [Value] -> m Value
-callLambda = \name env x t body args -> wrapError' ("while calling lambda " ++ maybe "(anonymous)" unVarName name) $ go Nothing env x t body args
+callLambda = \name env x t body args -> wrapError' ("while calling lambda " ++ maybe "(anonymous)" formatVarName name) $ go Nothing env x t body args
   where
     go name env x t body [] = return $ ValLambda name env x t body
-    go name env x _ body (e : args) = maybe id (\name -> wrapError' $ "while calling lambda " ++ unVarName name) name $ do
+    go name env x _ body (e : args) = maybe id (\name -> wrapError' $ "while calling lambda " ++ formatVarName name) name $ do
       body <- evaluateExpr ((x, e) : env) body
       case body of
         ValLambda name env x t body -> go name env x t body args
@@ -278,7 +278,7 @@ callValue f args = case (f, args) of
 evaluateExpr :: MonadError Error m => Env -> Expr -> m Value
 evaluateExpr env = \case
   Var x -> case lookup x env of
-    Nothing -> throwInternalError $ "undefined variable: " ++ unVarName x
+    Nothing -> throwInternalError $ "undefined variable: " ++ formatVarName x
     Just val -> return val
   Lit lit -> case lit of
     LitBuiltin ConvexHullTrickInit ts -> callBuiltin ConvexHullTrickInit ts []

--- a/src/Jikka/Core/Language/Beta.hs
+++ b/src/Jikka/Core/Language/Beta.hs
@@ -57,14 +57,14 @@ substituteToplevelExpr x e = \case
       then return $ ToplevelLet y t e' cont
       else do
         when (y `isFreeVar` e) $ do
-          throwInternalError $ "Jikka.Core.Language.Beta.substituteToplevelExpr: toplevel name conflicts: " ++ unVarName y
+          throwInternalError $ "Jikka.Core.Language.Beta.substituteToplevelExpr: toplevel name conflicts: " ++ formatVarName y
         ToplevelLet y t e' <$> substituteToplevelExpr x e cont
   ToplevelLetRec f args ret body cont -> do
     if f == x
       then return $ ToplevelLetRec f args ret body cont
       else do
         when (f `isFreeVar` e) $ do
-          throwInternalError $ "Jikka.Core.Language.Beta.substituteToplevelExpr: toplevel name conflicts: " ++ unVarName f
+          throwInternalError $ "Jikka.Core.Language.Beta.substituteToplevelExpr: toplevel name conflicts: " ++ formatVarName f
         (args, body) <-
           if x `elem` map fst args
             then return (args, body)

--- a/src/Jikka/Core/Language/NameCheck.hs
+++ b/src/Jikka/Core/Language/NameCheck.hs
@@ -26,7 +26,7 @@ define :: (MonadState [(VarName, Type)] m, MonadError Error m) => VarName -> Typ
 define x t = do
   env <- get
   case lookup x env of
-    Just t' -> throwInternalError $ "name conflict: " ++ unVarName x ++ ": " ++ formatType t ++ " and " ++ unVarName x ++ ": " ++ formatType t'
+    Just t' -> throwInternalError $ "name conflict: " ++ formatVarName x ++ ": " ++ formatType t ++ " and " ++ formatVarName x ++ ": " ++ formatType t'
     Nothing -> put $ (x, t) : env
 
 namecheckExpr' :: (MonadState [(VarName, Type)] m, MonadError Error m) => Expr -> m ()
@@ -34,7 +34,7 @@ namecheckExpr' = \case
   Var x -> do
     env <- get
     case lookup x env of
-      Nothing -> throwInternalError $ "undefined variable: " ++ unVarName x
+      Nothing -> throwInternalError $ "undefined variable: " ++ formatVarName x
       Just _ -> return ()
   Lit _ -> return ()
   App f e -> do

--- a/src/Jikka/Core/Language/Util.hs
+++ b/src/Jikka/Core/Language/Util.hs
@@ -17,18 +17,13 @@ import Jikka.Core.Language.BuiltinPatterns
 import Jikka.Core.Language.Expr
 
 genType :: MonadAlpha m => m Type
-genType = do
-  i <- nextCounter
-  return $ VarTy (TypeName ('$' : show i))
+genType = VarTy . TypeName Nothing . Just <$> nextCounter
 
 genVarName :: MonadAlpha m => VarName -> m VarName
-genVarName x = do
-  i <- nextCounter
-  let base = if unVarName x == "_" then "" else takeWhile (/= '$') (unVarName x)
-  return $ VarName (base ++ '$' : show i)
+genVarName (VarName x _) = VarName x . Just <$> nextCounter
 
 genVarName' :: MonadAlpha m => m VarName
-genVarName' = genVarName (VarName "_")
+genVarName' = genVarName (VarName Nothing Nothing)
 
 genVarName'' :: MonadAlpha m => Expr -> m VarName
 genVarName'' = \case

--- a/src/Jikka/Main/Subcommand/Convert.hs
+++ b/src/Jikka/Main/Subcommand/Convert.hs
@@ -13,6 +13,7 @@ module Jikka.Main.Subcommand.Convert (run) where
 
 import Data.Text (Text, pack)
 import qualified Jikka.CPlusPlus.Convert as FromCore
+import qualified Jikka.CPlusPlus.Convert.BurnFlavouredNames as BurnFlavouredNamesCPlusPlus
 import qualified Jikka.CPlusPlus.Format as FormatCPlusPlus
 import qualified Jikka.CPlusPlus.Language.Expr as CPlusPlus
 import Jikka.Common.Alpha
@@ -72,7 +73,9 @@ formatProgram = \case
   PythonProgram prog -> return . pack $ show prog -- TODO
   RestrictedPythonProgram prog -> FormatRestrictedPython.run prog
   CoreProgram prog -> FormatCore.run prog
-  CPlusPlusProgram prog -> FormatCPlusPlus.run prog
+  CPlusPlusProgram prog -> do
+    prog <- BurnFlavouredNamesCPlusPlus.run prog
+    FormatCPlusPlus.run prog
 
 run :: Target -> Target -> FilePath -> Text -> Either Error Text
 run source target path input = flip evalAlphaT 0 $ do

--- a/src/Jikka/Python/Convert/ToRestrictedPython.hs
+++ b/src/Jikka/Python/Convert/ToRestrictedPython.hs
@@ -26,7 +26,9 @@ import qualified Jikka.RestrictedPython.Language.Util as Y (genType)
 -- convert AST
 
 runIdent :: X.Ident' -> Y.VarName'
-runIdent (WithLoc loc (X.Ident x)) = WithLoc' (Just loc) (Y.VarName x)
+runIdent (WithLoc loc (X.Ident x)) =
+  let occ = if x == "_" then Nothing else Just x
+   in WithLoc' (Just loc) (Y.VarName occ Nothing)
 
 runAttribute :: X.Ident' -> Y.Attribute'
 runAttribute (WithLoc loc (X.Ident x)) = WithLoc' (Just loc) (Y.UnresolvedAttribute (Y.AttributeName x))

--- a/src/Jikka/RestrictedPython/Convert/DefaultMain.hs
+++ b/src/Jikka/RestrictedPython/Convert/DefaultMain.hs
@@ -28,18 +28,18 @@ lookupSolve = \case
   [] -> throwSymbolError "solve function is not defined"
   ToplevelAnnAssign _ _ _ : stmts -> lookupSolve stmts
   ToplevelFunctionDef f args ret body : stmts -> case value' f of
-    VarName "solve" -> return (loc' f, args, ret, body)
+    VarName (Just "solve") Nothing -> return (loc' f, args, ret, body)
     _ -> lookupSolve stmts
   ToplevelAssert _ : stmts -> lookupSolve stmts
 
 makeInputFormatFromType :: (MonadAlpha m, MonadError Error m) => Type -> m (FormatTree, String)
 makeInputFormatFromType = \case
   IntTy -> do
-    x <- unVarName . value' <$> genVarName'
+    x <- formatVarName . value' <$> genVarName'
     return (Exp (Var x), x)
   ListTy t -> do
-    n <- unVarName . value' <$> genVarName'
-    i <- unVarName . value' <$> genVarName'
+    n <- formatVarName . value' <$> genVarName'
+    i <- formatVarName . value' <$> genVarName'
     (body, x) <- makeInputFormatFromType t
     body <- (`mapFormatTreeM` body) $ \case
       Exp e -> return $ Exp (At e i)
@@ -50,10 +50,10 @@ makeInputFormatFromType = \case
 makeOutputFormatFromType' :: (MonadAlpha m, MonadError Error m) => Type -> m (FormatTree, String)
 makeOutputFormatFromType' = \case
   IntTy -> do
-    x <- unVarName . value' <$> genVarName'
+    x <- formatVarName . value' <$> genVarName'
     return (Exp (Var x), x)
   ListTy t -> do
-    i <- unVarName . value' <$> genVarName'
+    i <- formatVarName . value' <$> genVarName'
     (body, x) <- makeOutputFormatFromType' t
     body <- (`mapFormatTreeM` body) $ \case
       Exp e -> return $ Exp (At e i)

--- a/src/Jikka/RestrictedPython/Convert/ToCore.hs
+++ b/src/Jikka/RestrictedPython/Convert/ToCore.hs
@@ -47,11 +47,11 @@ withScope f = do
   return x
 
 runVarName :: X.VarName' -> Y.VarName
-runVarName (X.WithLoc' _ (X.VarName x)) = Y.VarName x
+runVarName (X.WithLoc' _ (X.VarName x)) = Y.VarName (Just x) Nothing
 
 runType :: MonadError Error m => X.Type -> m Y.Type
 runType = \case
-  X.VarTy (X.TypeName x) -> return $ Y.VarTy (Y.TypeName x)
+  X.VarTy (X.TypeName x) -> return $ Y.VarTy (Y.TypeName (Just x) Nothing)
   X.IntTy -> return Y.IntTy
   X.BoolTy -> return Y.BoolTy
   X.ListTy t -> Y.ListTy <$> runType t
@@ -60,14 +60,14 @@ runType = \case
   X.StringTy -> throwSemanticError "cannot use `str' type out of main function"
   X.SideEffectTy -> throwSemanticError "side-effect type must be used only as expr-statement" -- TODO: check in Jikka.RestrictedPython.Language.Lint
 
-runConstant :: MonadError Error m => X.Constant -> m Y.Expr
+runConstant :: (MonadAlpha m, MonadError Error m) => X.Constant -> m Y.Expr
 runConstant = \case
   X.ConstNone -> return $ Y.Tuple' []
   X.ConstInt n -> return $ Y.Lit (Y.LitInt n)
   X.ConstBool p -> return $ Y.Lit (Y.LitBool p)
   X.ConstBuiltin builtin -> runBuiltin builtin
 
-runBuiltin :: MonadError Error m => X.Builtin -> m Y.Expr
+runBuiltin :: (MonadAlpha m, MonadError Error m) => X.Builtin -> m Y.Expr
 runBuiltin builtin = do
   let go0 builtin = do
         return $ Y.Lit (Y.LitBuiltin builtin [])
@@ -109,10 +109,10 @@ runBuiltin builtin = do
       _ -> do
         ts <- mapM runType ts
         ret <- runType ret
-        let var i = Y.VarName ("xs" ++ show i)
-        let lam body = Y.Lam "go0" (Y.curryFunTy ts ret) (foldr (\(i, t) -> Y.Lam (var i) (Y.ListTy t)) body (zip [0 ..] ts))
-        let len = Y.Min1' Y.IntTy (foldr (Y.Cons' Y.IntTy) (Y.Nil' Y.IntTy) (zipWith (\i t -> Y.Len' t (Y.Var (var i))) [0 ..] ts))
-        let body = Y.Map' Y.IntTy ret (Y.Lam "i" Y.IntTy (Y.uncurryApp (Y.Var "go0") (map (Y.Var . var) [0 .. length ts - 1]))) (Y.Range1' len)
+        xs <- replicateM (length ts) Y.genVarName'
+        let lam body = Y.Lam "go0" (Y.curryFunTy ts ret) (foldr (\(i, t) -> Y.Lam (xs !! i) (Y.ListTy t)) body (zip [0 ..] ts))
+        let len = Y.Min1' Y.IntTy (foldr (Y.Cons' Y.IntTy) (Y.Nil' Y.IntTy) (zipWith (\i t -> Y.Len' t (Y.Var (xs !! i))) [0 ..] ts))
+        let body = Y.Map' Y.IntTy ret (Y.Lam "i" Y.IntTy (Y.uncurryApp (Y.Var "go0") (map (Y.Var . (xs !!)) [0 .. length ts - 1]))) (Y.Range1' len)
         return $ lam body
     X.BuiltinSorted t -> go1 Y.Sorted t
     X.BuiltinReversed t -> go1 Y.Reversed t
@@ -123,10 +123,10 @@ runBuiltin builtin = do
     X.BuiltinFilter t -> go1 Y.Filter t
     X.BuiltinZip ts -> do
       ts <- mapM runType ts
-      let var i = Y.VarName ("xs" ++ show i)
-      let lam body = foldr (\(i, t) -> Y.Lam (var i) (Y.ListTy t)) body (zip [0 ..] ts)
-      let len = Y.Min1' Y.IntTy (foldr (Y.Cons' Y.IntTy) (Y.Nil' Y.IntTy) (zipWith (\i t -> Y.Len' t (Y.Var (var i))) [0 ..] ts))
-      let body = Y.Map' Y.IntTy (Y.TupleTy ts) (Y.Lam "i" Y.IntTy (Y.uncurryApp (Y.Tuple' ts) (map (Y.Var . var) [0 .. length ts - 1]))) (Y.Range1' len)
+      xs <- replicateM (length ts) Y.genVarName'
+      let lam body = foldr (\(i, t) -> Y.Lam (xs !! i) (Y.ListTy t)) body (zip [0 ..] ts)
+      let len = Y.Min1' Y.IntTy (foldr (Y.Cons' Y.IntTy) (Y.Nil' Y.IntTy) (zipWith (\i t -> Y.Len' t (Y.Var (xs !! i))) [0 ..] ts))
+      let body = Y.Map' Y.IntTy (Y.TupleTy ts) (Y.Lam "i" Y.IntTy (Y.uncurryApp (Y.Tuple' ts) (map (Y.Var . (xs !!)) [0 .. length ts - 1]))) (Y.Range1' len)
       return $ lam body
     X.BuiltinAll -> go0 Y.All
     X.BuiltinAny -> go0 Y.Any
@@ -140,14 +140,14 @@ runBuiltin builtin = do
       when (n < 2) $ do
         throwTypeError $ "max expected 2 or more arguments, got " ++ show n
       t <- runType t
-      let args = map (\i -> Y.VarName ('x' : show i)) [0 .. n -1]
+      args <- replicateM n Y.genVarName'
       return $ Y.curryLam (map (,t) args) (foldr1 (Y.Max2' t) (map Y.Var args))
     X.BuiltinMin1 t -> go1 Y.Min1 t
     X.BuiltinMin t n -> do
       when (n < 2) $ do
         throwTypeError $ "max min 2 or more arguments, got " ++ show n
       t <- runType t
-      let args = map (\i -> Y.VarName ('x' : show i)) [0 .. n -1]
+      args <- replicateM n Y.genVarName'
       return $ Y.curryLam (map (,t) args) (foldr1 (Y.Min2' t) (map Y.Var args))
     X.BuiltinArgMax t -> go1 Y.ArgMax t
     X.BuiltinArgMin t -> go1 Y.ArgMin t

--- a/src/Jikka/RestrictedPython/Convert/ToCore.hs
+++ b/src/Jikka/RestrictedPython/Convert/ToCore.hs
@@ -47,11 +47,11 @@ withScope f = do
   return x
 
 runVarName :: X.VarName' -> Y.VarName
-runVarName (X.WithLoc' _ (X.VarName x)) = Y.VarName (Just x) Nothing
+runVarName (X.WithLoc' _ (X.VarName occ flavour)) = Y.VarName occ flavour
 
 runType :: MonadError Error m => X.Type -> m Y.Type
 runType = \case
-  X.VarTy (X.TypeName x) -> return $ Y.VarTy (Y.TypeName (Just x) Nothing)
+  X.VarTy (X.TypeName occ flavour) -> return $ Y.VarTy (Y.TypeName occ flavour)
   X.IntTy -> return Y.IntTy
   X.BoolTy -> return Y.BoolTy
   X.ListTy t -> Y.ListTy <$> runType t

--- a/src/Jikka/RestrictedPython/Evaluate.hs
+++ b/src/Jikka/RestrictedPython/Evaluate.hs
@@ -45,7 +45,7 @@ lookupLocal x = do
   local <- get
   case M.lookup (value' x) (unLocal local) of
     Just v -> return v
-    Nothing -> throwInternalErrorAt' (loc' x) $ "undefined variable: " ++ unVarName (value' x)
+    Nothing -> throwInternalErrorAt' (loc' x) $ "undefined variable: " ++ formatVarName (value' x)
 
 assignSubscriptedTarget :: (MonadReader Global m, MonadState Local m, MonadError Error m) => Target' -> Expr' -> Value -> m ()
 assignSubscriptedTarget f index v = wrapAt' (loc' f) $ do
@@ -270,7 +270,7 @@ evalExpr e0 = wrapAt' (loc' e0) $ case value' e0 of
         global <- ask
         case M.lookup (value' x) (unGlobal global) of
           Just v -> return v
-          Nothing -> throwInternalError $ "undefined variable: " ++ unVarName (value' x)
+          Nothing -> throwInternalError $ "undefined variable: " ++ formatVarName (value' x)
   List _ es -> ListVal . V.fromList <$> mapM evalExpr es
   Tuple es -> TupleVal <$> mapM evalExpr es
   SubscriptSlice e from to step -> do
@@ -528,7 +528,7 @@ lookupGlobal :: MonadError Error m => VarName' -> Global -> m Value
 lookupGlobal x global =
   case M.lookup (value' x) (unGlobal global) of
     Just y -> return y
-    Nothing -> throwSymbolErrorAt' (loc' x) $ "undefined variable: " ++ unVarName (value' x)
+    Nothing -> throwSymbolErrorAt' (loc' x) $ "undefined variable: " ++ formatVarName (value' x)
 
 runWithGlobal :: MonadError Error m => Global -> Expr' -> m Value
 runWithGlobal global e = do
@@ -548,7 +548,7 @@ makeGlobal prog = do
 run :: MonadError Error m => Program -> [Value] -> m Value
 run prog args = wrapError' "Jikka.RestrictedPython.Evaluate" $ do
   global <- makeGlobal prog
-  solve <- lookupGlobal (withoutLoc (VarName "solve")) global
+  solve <- lookupGlobal (withoutLoc (VarName (Just "solve") Nothing)) global
   runWithGlobal' global solve args
 
 evalBinOp :: MonadError Error m => Value -> Operator -> Value -> m Value

--- a/src/Jikka/RestrictedPython/Format.hs
+++ b/src/Jikka/RestrictedPython/Format.hs
@@ -30,7 +30,7 @@ import Jikka.RestrictedPython.Language.Expr
 
 formatType :: Type -> String
 formatType t = case t of
-  VarTy x -> unTypeName x
+  VarTy x -> formatTypeName x
   IntTy -> "int"
   BoolTy -> "bool"
   ListTy t -> "List[" ++ formatType t ++ "]"
@@ -104,7 +104,7 @@ formatComprehension (Comprehension x iter ifs) =
 formatTarget :: Target' -> String
 formatTarget (WithLoc' _ x) = case x of
   SubscriptTrg x e -> formatTarget x ++ "[" ++ formatExpr e ++ "]"
-  NameTrg x -> unVarName (value' x)
+  NameTrg x -> formatVarName (value' x)
   TupleTrg xs -> case xs of
     [] -> "()"
     [x] -> "(" ++ formatTarget x ++ ",)"
@@ -117,7 +117,7 @@ formatExpr (WithLoc' _ e0) = case e0 of
   UnaryOp op e -> formatUnaryOp op ++ " " ++ formatExpr e
   Lambda args body -> case args of
     [] -> "lambda: " ++ formatExpr body
-    _ -> "lambda " ++ intercalate ", " (map (unVarName . value' . fst) args) ++ ": " ++ formatExpr body
+    _ -> "lambda " ++ intercalate ", " (map (formatVarName . value' . fst) args) ++ ": " ++ formatExpr body
   IfExp e1 e2 e3 -> formatExpr e2 ++ " if " ++ formatExpr e1 ++ " else " ++ formatExpr e3
   ListComp e comp -> "[" ++ formatExpr e ++ " " ++ formatComprehension comp ++ "]"
   Compare e1 op e2 -> formatExpr e1 ++ " " ++ formatCmpOp op ++ " " ++ formatExpr e2
@@ -128,7 +128,7 @@ formatExpr (WithLoc' _ e0) = case e0 of
   Attribute e (WithLoc' _ x) -> formatExpr e ++ "." ++ formatAttribute x
   Subscript e1 e2 -> formatExpr e1 ++ "[" ++ formatExpr e2 ++ "]"
   Starred e -> "*" ++ formatExpr e
-  Name x -> unVarName (value' x)
+  Name x -> formatVarName (value' x)
   List _ es -> "[" ++ intercalate ", " (map formatExpr es) ++ "]"
   Tuple es -> case es of
     [] -> "()"
@@ -157,8 +157,8 @@ formatStatement = \case
 
 formatToplevelStatement :: ToplevelStatement -> [String]
 formatToplevelStatement = \case
-  ToplevelAnnAssign x t e -> [unVarName (value' x) ++ ": " ++ formatType t ++ " = " ++ formatExpr e]
-  ToplevelFunctionDef f args ret body -> ["def " ++ unVarName (value' f) ++ "(" ++ intercalate ", " (map (\(x, t) -> unVarName (value' x) ++ ": " ++ formatType t) args) ++ ") -> " ++ formatType ret ++ ":", indent] ++ concatMap formatStatement body ++ [dedent]
+  ToplevelAnnAssign x t e -> [formatVarName (value' x) ++ ": " ++ formatType t ++ " = " ++ formatExpr e]
+  ToplevelFunctionDef f args ret body -> ["def " ++ formatVarName (value' f) ++ "(" ++ intercalate ", " (map (\(x, t) -> formatVarName (value' x) ++ ": " ++ formatType t) args) ++ ") -> " ++ formatType ret ++ ":", indent] ++ concatMap formatStatement body ++ [dedent]
   ToplevelAssert e -> ["assert " ++ formatExpr e]
 
 formatProgram :: Program -> [String]

--- a/src/Jikka/RestrictedPython/Language/Builtin.hs
+++ b/src/Jikka/RestrictedPython/Language/Builtin.hs
@@ -126,7 +126,7 @@ resolveBuiltin x n = wrapAt' (loc' x) . wrapError' "Jikka.RestrictedPython.Langu
       e <- resolveUniqueBuiltin x
       case value' e of
         Constant (ConstBuiltin _) -> return e
-        _ -> throwInternalError $ "not exhaustive: " ++ unVarName (value' x)
+        _ -> throwInternalError $ "not exhaustive: " ++ formatVarName (value' x)
 
 formatBuiltin :: Builtin -> String
 formatBuiltin = \case
@@ -294,7 +294,7 @@ resolveAttribute e@(WithLoc' _ (Name (WithLoc' _ "math"))) x = wrapAt' (loc' x) 
   _ -> return $ Attribute e x
 resolveAttribute e@(WithLoc' _ (Name (WithLoc' _ "jikka"))) x = wrapAt' (loc' x) $ case value' x of
   UnresolvedAttribute x' ->
-    let x'' = VarName (unAttributeName x')
+    let x'' = VarName (Just (unAttributeName x')) Nothing
      in if x'' `S.notMember` additionalBuiltinNames
           then throwSymbolError $ "unknown attribute: " ++ unAttributeName x'
           else value' <$> resolveUniqueBuiltin (x $> x'')

--- a/src/Jikka/RestrictedPython/Language/Expr.hs
+++ b/src/Jikka/RestrictedPython/Language/Expr.hs
@@ -12,7 +12,7 @@
 module Jikka.RestrictedPython.Language.Expr
   ( -- * types
     TypeName (..),
-    unTypeName,
+    formatTypeName,
     Type (..),
     pattern NoneTy,
 
@@ -31,7 +31,7 @@ module Jikka.RestrictedPython.Language.Expr
 
     -- * exprs
     VarName (..),
-    unVarName,
+    formatVarName,
     module Jikka.Common.Location,
     VarName',
     Expr (..),
@@ -48,21 +48,28 @@ module Jikka.RestrictedPython.Language.Expr
   )
 where
 
-import Data.String (IsString)
+import Data.String
 import Jikka.Common.Location
+import Jikka.Common.Name
 import Jikka.Python.Language.Expr (BoolOp (..), CmpOp (..), Operator (..), UnaryOp (..))
 
-newtype VarName = VarName String deriving (Eq, Ord, Show, Read, IsString)
+data VarName = VarName OccName NameFlavour deriving (Eq, Ord, Show, Read)
 
-unVarName :: VarName -> String
-unVarName (VarName x) = x
+instance IsString VarName where
+  fromString = uncurry VarName . toFlavouredName
+
+formatVarName :: VarName -> String
+formatVarName (VarName occ flavour) = formatFlavouredName occ flavour
 
 type VarName' = WithLoc' VarName
 
-newtype TypeName = TypeName String deriving (Eq, Ord, Show, Read, IsString)
+data TypeName = TypeName OccName NameFlavour deriving (Eq, Ord, Show, Read)
 
-unTypeName :: TypeName -> String
-unTypeName (TypeName x) = x
+instance IsString TypeName where
+  fromString = uncurry TypeName . toFlavouredName
+
+formatTypeName :: TypeName -> String
+formatTypeName (TypeName occ flavour) = formatFlavouredName occ flavour
 
 newtype AttributeName = AttributeName String deriving (Eq, Ord, Show, Read, IsString)
 

--- a/src/Jikka/RestrictedPython/Language/Util.hs
+++ b/src/Jikka/RestrictedPython/Language/Util.hs
@@ -64,18 +64,13 @@ import Jikka.Common.Location
 import Jikka.RestrictedPython.Language.Expr
 
 genType :: MonadAlpha m => m Type
-genType = do
-  i <- nextCounter
-  return $ VarTy (TypeName ('$' : show i))
+genType = VarTy . TypeName Nothing . Just <$> nextCounter
 
 genVarName :: MonadAlpha m => VarName' -> m VarName'
-genVarName x = do
-  i <- nextCounter
-  let base = if unVarName (value' x) == "_" then "" else takeWhile (/= '$') (unVarName (value' x))
-  return $ WithLoc' (loc' x) (VarName (base ++ '$' : show i))
+genVarName x@(WithLoc' _ (VarName occ _)) = WithLoc' (loc' x) . VarName occ . Just <$> nextCounter
 
 genVarName' :: MonadAlpha m => m VarName'
-genVarName' = genVarName (withoutLoc (VarName "_"))
+genVarName' = genVarName (withoutLoc (VarName Nothing Nothing))
 
 freeTyVars :: Type -> [TypeName]
 freeTyVars = nub . go
@@ -353,4 +348,4 @@ targetToExpr e =
     SubscriptTrg e1 e2 -> Subscript (targetToExpr e1) e2
 
 toplevelMainDef :: [Statement] -> Program
-toplevelMainDef body = [ToplevelFunctionDef (WithLoc' Nothing (VarName "main")) [] IntTy body]
+toplevelMainDef body = [ToplevelFunctionDef (WithLoc' Nothing (VarName (Just "main") Nothing)) [] IntTy body]

--- a/test/Jikka/CPlusPlus/Convert/FromCoreSpec.hs
+++ b/test/Jikka/CPlusPlus/Convert/FromCoreSpec.hs
@@ -5,8 +5,10 @@ module Jikka.CPlusPlus.Convert.FromCoreSpec
   )
 where
 
+import qualified Jikka.CPlusPlus.Convert.BurnFlavouredNames as Y_BurnFlavouredNames
 import Jikka.CPlusPlus.Convert.FromCore
 import qualified Jikka.CPlusPlus.Language.Expr as Y
+import qualified Jikka.CPlusPlus.Language.Util as Y
 import Jikka.Common.Alpha
 import Jikka.Common.Error
 import qualified Jikka.Core.Language.BuiltinPatterns as X
@@ -14,7 +16,9 @@ import qualified Jikka.Core.Language.Expr as X
 import Test.Hspec
 
 run' :: X.Program -> Either Error Y.Program
-run' = flip evalAlphaT 0 . run
+run' prog = flip evalAlphaT 0 $ do
+  prog <- run prog
+  Y_BurnFlavouredNames.run prog
 
 spec :: Spec
 spec = describe "run" $ do
@@ -34,35 +38,35 @@ spec = describe "run" $ do
     let expectedF =
           Y.FunDef
             Y.TyInt64
-            "f_0"
-            [(Y.TyInt64, "n_1")]
-            [ Y.Declare Y.TyInt64 "x2" Y.DeclareDefault,
+            "f"
+            [(Y.TyInt64, "n")]
+            [ Y.Declare Y.TyInt64 "x" Y.DeclareDefault,
               Y.If
-                (Y.BinOp Y.Equal (Y.Var "n_1") (Y.Lit (Y.LitInt64 0)))
-                [Y.Assign (Y.AssignExpr Y.SimpleAssign (Y.LeftVar "x2") (Y.Lit (Y.LitInt64 1)))]
+                (Y.BinOp Y.Equal (Y.Var "n") (Y.Lit (Y.LitInt64 0)))
+                [Y.Assign (Y.AssignExpr Y.SimpleAssign (Y.LeftVar "x") (Y.Lit (Y.LitInt64 1)))]
                 ( Just
                     [ Y.Assign
                         ( Y.AssignExpr
                             Y.SimpleAssign
-                            (Y.LeftVar "x2")
+                            (Y.LeftVar "x")
                             ( Y.BinOp
                                 Y.Mul
-                                (Y.Var "n_1")
-                                ( Y.CallExpr
-                                    (Y.Var "f_0")
-                                    [Y.BinOp Y.Sub (Y.Var "n_1") (Y.Lit (Y.LitInt64 1))]
+                                (Y.Var "n")
+                                ( Y.Call'
+                                    (Y.Function "f" [])
+                                    [Y.BinOp Y.Sub (Y.Var "n") (Y.Lit (Y.LitInt64 1))]
                                 )
                             )
                         )
                     ]
                 ),
-              Y.Return (Y.Var "x2")
+              Y.Return (Y.Var "x")
             ]
     let expectedSolve =
           Y.FunDef
             Y.TyInt64
             "solve"
-            [(Y.TyInt64, "a4")]
-            [Y.Return (Y.CallExpr (Y.Var "f_0") [Y.Var "a4"])]
+            [(Y.TyInt64, "a")]
+            [Y.Return (Y.Call' (Y.Function "f" []) [Y.Var "a"])]
     let expected = Y.Program [expectedF, expectedSolve]
     run' prog `shouldBe` Right expected

--- a/test/Jikka/CPlusPlus/Convert/MoveSemanticsSpec.hs
+++ b/test/Jikka/CPlusPlus/Convert/MoveSemanticsSpec.hs
@@ -7,6 +7,7 @@ where
 
 import Jikka.CPlusPlus.Convert.MoveSemantics
 import Jikka.CPlusPlus.Language.Expr
+import Jikka.CPlusPlus.Language.Util
 import Jikka.Common.Alpha
 import Jikka.Common.Error
 import Test.Hspec
@@ -52,10 +53,10 @@ spec = describe "run" $ do
                 "func"
                 [(TyVector TyInt32, "a")]
                 [ Declare (TyVector TyInt32) "b" (DeclareCopy (Var "a")),
-                  ExprStatement (Call (Method "push_back") [Var "b", Lit (LitInt32 10)]),
+                  ExprStatement (Call' (Method "push_back") [Var "b", Lit (LitInt32 10)]),
                   Declare (TyVector TyInt32) "c" (DeclareCopy (Var "b")),
-                  ExprStatement (Call (Method "push_back") [Var "b", Lit (LitInt32 10)]),
-                  Return (BinOp Add (Call MethodSize [Var "b"]) (Call MethodSize [Var "c"]))
+                  ExprStatement (Call' (Method "push_back") [Var "b", Lit (LitInt32 10)]),
+                  Return (BinOp Add (Call' MethodSize [Var "b"]) (Call' MethodSize [Var "c"]))
                 ]
             ]
     let expected =
@@ -64,10 +65,10 @@ spec = describe "run" $ do
                 TyInt32
                 "func"
                 [(TyVector TyInt32, "a")]
-                [ ExprStatement (Call (Method "push_back") [Var "a", Lit (LitInt32 10)]),
+                [ ExprStatement (Call' (Method "push_back") [Var "a", Lit (LitInt32 10)]),
                   Declare (TyVector TyInt32) "c" (DeclareCopy (Var "a")),
-                  ExprStatement (Call (Method "push_back") [Var "a", Lit (LitInt32 10)]),
-                  Return (BinOp Add (Call MethodSize [Var "a"]) (Call MethodSize [Var "c"]))
+                  ExprStatement (Call' (Method "push_back") [Var "a", Lit (LitInt32 10)]),
+                  Return (BinOp Add (Call' MethodSize [Var "a"]) (Call' MethodSize [Var "c"]))
                 ]
             ]
     run' prog `shouldBe` Right expected
@@ -127,7 +128,7 @@ spec = describe "run" $ do
                 "func"
                 [(TyVector TyInt32, "a")]
                 [ Declare (TyVector TyInt32) "b" (DeclareCopy (Var "a")),
-                  Assign (AssignExpr AddAssign (LeftAt (LeftVar "b") (Lit (LitInt32 0))) (Call At [Var "a", Lit (LitInt32 1)])),
+                  Assign (AssignExpr AddAssign (LeftAt (LeftVar "b") (Lit (LitInt32 0))) (Call' At [Var "a", Lit (LitInt32 1)])),
                   Assign (AssignExpr SimpleAssign (LeftVar "a") (Var "b")),
                   Return (Var "a")
                 ]
@@ -138,7 +139,7 @@ spec = describe "run" $ do
                 (TyVector TyInt32)
                 "func"
                 [(TyVector TyInt32, "a")]
-                [ Assign (AssignExpr AddAssign (LeftAt (LeftVar "a") (Lit (LitInt32 0))) (Call At [Var "a", Lit (LitInt32 1)])),
+                [ Assign (AssignExpr AddAssign (LeftAt (LeftVar "a") (Lit (LitInt32 0))) (Call' At [Var "a", Lit (LitInt32 1)])),
                   Return (Var "a")
                 ]
             ]

--- a/test/Jikka/CPlusPlus/Convert/UnpackTuplesSpec.hs
+++ b/test/Jikka/CPlusPlus/Convert/UnpackTuplesSpec.hs
@@ -5,14 +5,18 @@ module Jikka.CPlusPlus.Convert.UnpackTuplesSpec
   )
 where
 
+import qualified Jikka.CPlusPlus.Convert.BurnFlavouredNames as Y_BurnFlavouredNames
 import Jikka.CPlusPlus.Convert.UnpackTuples
 import Jikka.CPlusPlus.Language.Expr
+import Jikka.CPlusPlus.Language.Util
 import Jikka.Common.Alpha
 import Jikka.Common.Error
 import Test.Hspec
 
 run' :: Program -> Either Error Program
-run' = flip evalAlphaT 0 . run
+run' prog = flip evalAlphaT 0 $ do
+  prog <- run prog
+  Y_BurnFlavouredNames.run prog
 
 spec :: Spec
 spec = describe "run" $ do
@@ -23,8 +27,8 @@ spec = describe "run" $ do
                 TyInt
                 "func"
                 [(TyInt, "a")]
-                [ Declare (TyTuple [TyInt, TyBool]) "b" (DeclareCopy (Call (StdTuple [TyInt, TyBool]) [Var "a", Lit (LitBool True)])),
-                  Return (BinOp Add (Call (StdGet 0) [Var "b"]) (Call (StdGet 1) [Var "b"]))
+                [ Declare (TyTuple [TyInt, TyBool]) "b" (DeclareCopy (Call' (StdTuple [TyInt, TyBool]) [Var "a", Lit (LitBool True)])),
+                  Return (BinOp Add (Call' (StdGet 0) [Var "b"]) (Call' (StdGet 1) [Var "b"]))
                 ]
             ]
     let expected =
@@ -33,9 +37,9 @@ spec = describe "run" $ do
                 TyInt
                 "func"
                 [(TyInt, "a")]
-                [ Declare TyInt "b_0" (DeclareCopy (Var "a")),
-                  Declare TyBool "b_1" (DeclareCopy (Lit (LitBool True))),
-                  Return (BinOp Add (Var "b_0") (Var "b_1"))
+                [ Declare TyInt "b" (DeclareCopy (Var "a")),
+                  Declare TyBool "b2" (DeclareCopy (Lit (LitBool True))),
+                  Return (BinOp Add (Var "b") (Var "b2"))
                 ]
             ]
     run' prog `shouldBe` Right expected
@@ -46,8 +50,8 @@ spec = describe "run" $ do
                 TyInt32
                 "func"
                 [(TyInt32, "a")]
-                [ Declare (TyArray TyInt32 3) "b" (DeclareCopy (Call (ArrayExt TyInt32) [Var "a", Lit (LitInt32 10), Lit (LitInt32 15)])),
-                  Return (BinOp Add (Call At [Var "b", Lit (LitInt32 0)]) (Call At [Var "b", Lit (LitInt32 2)]))
+                [ Declare (TyArray TyInt32 3) "b" (DeclareCopy (Call' (ArrayExt TyInt32) [Var "a", Lit (LitInt32 10), Lit (LitInt32 15)])),
+                  Return (BinOp Add (Call' At [Var "b", Lit (LitInt32 0)]) (Call' At [Var "b", Lit (LitInt32 2)]))
                 ]
             ]
     let expected =
@@ -56,10 +60,10 @@ spec = describe "run" $ do
                 TyInt32
                 "func"
                 [(TyInt32, "a")]
-                [ Declare TyInt32 "b_0" (DeclareCopy (Var "a")),
-                  Declare TyInt32 "b_1" (DeclareCopy (Lit (LitInt32 10))),
-                  Declare TyInt32 "b_2" (DeclareCopy (Lit (LitInt32 15))),
-                  Return (BinOp Add (Var "b_0") (Var "b_2"))
+                [ Declare TyInt32 "b" (DeclareCopy (Var "a")),
+                  Declare TyInt32 "b2" (DeclareCopy (Lit (LitInt32 10))),
+                  Declare TyInt32 "b3" (DeclareCopy (Lit (LitInt32 15))),
+                  Return (BinOp Add (Var "b") (Var "b3"))
                 ]
             ]
     run' prog `shouldBe` Right expected

--- a/test/Jikka/CPlusPlus/FormatSpec.hs
+++ b/test/Jikka/CPlusPlus/FormatSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Jikka.CPlusPlus.FormatSpec
   ( spec,
   )
@@ -6,6 +8,7 @@ where
 import Data.List
 import Jikka.CPlusPlus.Format
 import Jikka.CPlusPlus.Language.Expr
+import Jikka.CPlusPlus.Language.Util
 import Test.Hspec
 
 run'' :: Program -> [String]
@@ -19,18 +22,18 @@ spec = do
             Program
               [ FunDef
                   TyInt64
-                  (VarName "solve")
-                  [(TyInt32, VarName "n")]
-                  [ Declare TyInt64 (VarName "x") (DeclareCopy (Lit (LitInt64 0))),
+                  "solve"
+                  [(TyInt32, "n")]
+                  [ Declare TyInt64 "x" (DeclareCopy (Lit (LitInt64 0))),
                     For
                       TyInt32
-                      (VarName "i")
+                      "i"
                       (Lit (LitInt32 0))
-                      (BinOp LessThan (Var (VarName "i")) (Var (VarName "n")))
-                      (AssignIncr (LeftVar (VarName "i")))
-                      [ Assign (AssignExpr AddAssign (LeftVar (VarName "x")) (Call (Cast TyInt64) [Var (VarName "i")]))
+                      (BinOp LessThan (Var "i") (Var "n"))
+                      (AssignIncr (LeftVar "i"))
+                      [ Assign (AssignExpr AddAssign (LeftVar "x") (Call' (Cast TyInt64) [Var "i"]))
                       ],
-                    Return (Var (VarName "x"))
+                    Return (Var "x")
                   ]
               ]
       let formatted =
@@ -49,18 +52,18 @@ spec = do
             Program
               [ FunDef
                   TyInt64
-                  (VarName "solve")
-                  [(TyInt32, VarName "n"), (TyVector TyInt64, VarName "h")]
-                  [ Declare TyInt64 (VarName "x") (DeclareCopy (Lit (LitInt64 0))),
+                  "solve"
+                  [(TyInt32, "n"), (TyVector TyInt64, "h")]
+                  [ Declare TyInt64 "x" (DeclareCopy (Lit (LitInt64 0))),
                     For
                       TyInt32
-                      (VarName "i")
+                      "i"
                       (Lit (LitInt32 2))
-                      (BinOp LessThan (Var (VarName "i")) (Var (VarName "n")))
-                      (AssignIncr (LeftVar (VarName "i")))
-                      [ Assign (AssignExpr AddAssign (LeftVar (VarName "x")) (Call At [Var (VarName "h"), BinOp Sub (Var (VarName "i")) (Lit (LitInt32 2))]))
+                      (BinOp LessThan (Var "i") (Var "n"))
+                      (AssignIncr (LeftVar "i"))
+                      [ Assign (AssignExpr AddAssign (LeftVar "x") (Call' At [Var "h", BinOp Sub (Var "i") (Lit (LitInt32 2))]))
                       ],
-                    Return (Var (VarName "x"))
+                    Return (Var "x")
                   ]
               ]
       let formatted =


### PR DESCRIPTION
## 説明

たとえば以下のようなコードがあったとする。

``` python
def f(n: int) -> int:
     n = n + 1
     n = n + 1
     n = n + 1
     return n * n
```

これは変数名が衝突していて面倒なので、内部的には

``` python
def f(n: int) -> int:
     n$2 = n + 1
     n$3 = n$2 + 1
     n$4 = n$3 + 1
     return n$4 * n$4
```

みたいに変数名を付け替えています。
このときに変数名全体をひとつの文字列として "n$3" みたいにして保持しています。
すると変数名をさらに付け替えるときに "n$3" から "n" を切り出して別の数字を付けて "n$5" にして…となにかと面倒です。そこで ("n", 3) というタプルで持つようにすると実装がきれいになります。

参考: https://hackage.haskell.org/package/template-haskell-2.17.0.0/docs/Language-Haskell-TH-Syntax.html#t:Name